### PR TITLE
Add missing details to toolbox manifesto

### DIFF
--- a/src/system/f/math/Tan/README.md
+++ b/src/system/f/math/Tan/README.md
@@ -1,0 +1,230 @@
+# Zero-Waste Media Toolbox
+
+Below is an amplified, developer-first manifesto and scaffold for a zero-waste, interoperable media toolbox.
+
+It covers:
+1. Project layout with clear boundaries
+2. APIs & CLI examples for each core module
+3. Interop targets and binding patterns
+4. Documentation & testing guidelines
+5. Quickstart README snippet
+
+⸻
+
+```
+media-toolbox/
+├── core/                          ← Pure logic, no platform APIs
+│   ├── audio/
+│   │   ├── Mixer.kt               ← mix PCM streams
+│   │   ├── MixerCLI.kt            ← CLI wrapper
+│   │   └── MixerInterop.kt        ← C externs / WASM exports
+│   ├── visual/
+│   │   ├── BlurScaler.kt          ← rescale-based blur
+│   │   └── BlurCLI.kt             ← CLI wrapper
+│   ├── ai/
+│   │   ├── TorchSplicer.kt        ← TorchScript runner
+│   │   └── SpliceCLI.kt           ← CLI wrapper
+│   └── control/
+│       └── ParamRouter.kt         ← maps inputs → params
+│
+├── bindings/                      ← Language bindings
+│   ├── kotlin-mpp/                ← Kotlin Multiplatform (JVM/Native/WASM)
+│   ├── python/                    ← PyPI package & Py4J bridge
+│   └── node/                      ← npm package (WASM + JS API)
+│
+├── samples/                       ← Minimal “hello world” apps
+│   ├── cli-audio-mix/             ← mix two WAV files
+│   ├── cli-visual-blur/           ← blur an image
+│   └── gui-preview/               ← Swing/JavaFX quick demo
+│
+├── docs/                          ← Living documentation
+│   ├── README.md                  ← Quickstart + overview
+│   ├── API_REFERENCE.md           ← Detailed docs per class
+│   └── INTEROP_GUIDE.md           ← How to bind to other langs
+│
+├── tests/                         ← Unit & integration tests
+│   ├── audio/                     ← mock PCM buffers, edge cases
+│   ├── visual/                    ← test images & blur outputs
+│   └── ai/                        ← stub models & golden results
+│
+└── tools/                         ← Dev utilities
+    ├── build-scripts/             ← Gradle, pip, npm configs
+    └── ci/                        ← CI pipelines & linting rules
+```
+
+⸻
+
+## Core Module APIs & CLI Examples
+
+### AudioMixerEngine (core/audio/Mixer.kt)
+
+```kotlin
+class AudioMixerEngine {
+  private val streams = mutableMapOf<String, FloatArray>()
+  private val volumes = mutableMapOf<String, Float>()
+
+  fun addStream(id: String, pcm: FloatArray) {
+    streams[id] = pcm
+    volumes[id] = 1.0f
+  }
+
+  fun setVolume(id: String, volume: Float) {
+    require(volumes.containsKey(id)) { "Stream $id not found" }
+    volumes[id] = volume.coerceIn(0f, 1f)
+  }
+
+  fun mix(): FloatArray {
+    val length = streams.values.firstOrNull()?.size ?: return FloatArray(0)
+    val output = FloatArray(length)
+    for ((id, pcm) in streams) {
+      val vol = volumes[id] ?: 1.0f
+      for (i in 0 until length) {
+        output[i] = (output[i] + pcm[i] * vol).coerceIn(-1f, 1f)
+      }
+    }
+    return output
+  }
+}
+```
+
+MixerCLI.kt
+
+```kotlin
+fun main(args: Array<String>) {
+  if (args.size < 3) {
+    println("Usage: MixerCLI in1.wav in2.wav [vol1 vol2] -o out.wav")
+    return
+  }
+  // parse inputs, decode WAV → FloatArray, mix, encode WAV
+}
+```
+
+### BlurScaler (core/visual/BlurScaler.kt)
+
+```kotlin
+object BlurScaler {
+  /**
+   * scaleFactor: 7→128
+   * image: 2D pixel array
+   * Returns blurred image via down-/up-scale
+   */
+  fun blurScale(
+    image: BufferedImage,
+    scaleFactor: Int
+  ): BufferedImage {
+    val ratio = 128f / scaleFactor
+    val w = (image.width / ratio).toInt()
+    val h = (image.height / ratio).toInt()
+    val tmp = BufferedImage(w, h, image.type)
+    tmp.graphics.drawImage(
+      image, 0, 0, w, h, null
+    )
+    val result = BufferedImage(image.width, image.height, image.type)
+    result.graphics.drawImage(
+      tmp, 0, 0, image.width, image.height, null
+    )
+    return result
+  }
+}
+```
+
+BlurCLI.kt
+
+```kotlin
+fun main(args: Array<String>) {
+  // Usage: BlurCLI input.png scale(7–128) output.png
+}
+```
+
+⸻
+
+## Interop Targets & Patterns
+
+| Target     | Bridge                  | Example                                         |
+|------------|------------------------|-------------------------------------------------|
+| Kotlin MPP | Kotlin/Native & WASM   | `@JsExport` for JS, native libraries for Swift   |
+| Python     | Py4J or JNI Binding    | `mixer = MediaToolbox.Audio.Mixer()`             |
+| Node.js    | WASM + JS wrapper      | `import { blurScale } from 'media-toolbox'`      |
+| C/C++      | extern "C" in MixerInterop.kt | `mixAudio(float* pcm1, int len1, ...)` |
+| REST API   | Ktor HTTPInterface.kt  | `/mix?url1=...&url2=...`                         |
+
+⸻
+
+## Documentation & Testing Guidelines
+
+- Docstrings in all public APIs, with `@param`, `@return`, usage examples
+- `API_REFERENCE.md` auto-generated via Dokka
+- `INTEROP_GUIDE.md` details how to build & consume each binding
+- Unit tests for edge cases: zero-length streams, extreme scale factors, clipping behavior
+- Integration tests: CLI binary called in CI, comparing output bit-exact against golden files
+- Benchmarks: jitter, latency, memory footprint reported in CI logs
+
+⸻
+
+## Quickstart README Snippet
+
+```markdown
+# Media Toolbox
+
+A zero-waste, developer-first toolkit for audio mixing, video blur, and AI-splicing.
+
+## Installation
+
+### JVM
+```bash
+git clone … && ./gradlew install
+```
+
+Python (PyPI)
+
+```bash
+pip install media-toolbox
+```
+
+Node.js
+
+```bash
+npm install media-toolbox
+```
+
+### Usage
+
+Mix two audio files
+
+```
+mixer-cli vocals.wav beat.wav --volumes 0.8 1.0 -o mix.wav
+```
+
+Blur an image
+
+```
+blur-cli input.png 32 output.png
+```
+
+Apply AI splice
+
+```
+splice-cli mix.wav model.pt --output remix.wav
+```
+
+### Library Example (Kotlin)
+
+```kotlin
+val mixer = AudioMixerEngine()
+mixer.addStream("v", loadWav("vocals.wav"))
+mixer.addStream("b", loadWav("beat.wav"))
+mixer.setVolume("v", 0.7f)
+val mix = mixer.mix()
+saveWav(mix, "mix.wav")
+```
+```
+
+With this scaffold in place, every developer can:
+
+- Pick any module and run it in isolation
+- Bind it into mobile, desktop, server, or web
+- Extend with new formats (e.g. video codecs, AI models)
+- Test and benchmark in CI before merging
+
+Ready to spin up the initial repo, or drill into any module with working code?
+


### PR DESCRIPTION
## Summary
- expand `Zero-Waste Media Toolbox` README with missing separators and closing question

## Testing
- `npm install`
- `npm test` *(fails: Cannot find module '../../system/_ids')*

------
https://chatgpt.com/codex/tasks/task_e_6877651caa0c832595e73164c6678ebc