### PR TITLE
Add personality profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ console.log(mergeSort.take('a')) // [1, 2]
 npm test
 ```
 
+## Personality Profiles
+
+A system instance can apply different personality profiles that tint the base
+theme color. A profile defines a base color and a scalar value used to adjust
+the tone.
+
+Use the new personality API to switch profiles at runtime:
+
+```ts
+system.setPersonality('playful')
+```
+
+
 ## Links
 
 List of related web applications:

--- a/src/API.ts
+++ b/src/API.ts
@@ -2,6 +2,7 @@ import { Waiter } from './Waiter'
 import { IOElement } from './client/IOElement'
 import { LayoutNode } from './client/LayoutNode'
 import { Theme } from './client/theme'
+import { Personality } from './client/personality'
 import { Rect } from './client/util/geometry/types'
 import { System } from './system'
 import { Tag } from './system/platform/Style'
@@ -367,5 +368,9 @@ export type API = {
   }
   theme: {
     setTheme(theme: Theme): Promise<void>
+  }
+  personality: {
+    setPersonality(personality: Personality): Promise<void>
+    getPersonality(): Personality
   }
 }

--- a/src/boot/index.ts
+++ b/src/boot/index.ts
@@ -7,6 +7,11 @@ import { Registry } from '../Registry'
 import { Component } from '../client/component'
 import { icons } from '../client/icons'
 import { themeColor } from '../client/theme'
+import {
+  DEFAULT_PERSONALITY,
+  PERSONALITY_PROFILES,
+  Personality,
+} from '../client/personality'
 import { InvalidStateError } from '../exception/InvalidStateError'
 import { start } from '../start'
 import { BootOpt, System } from '../system'
@@ -96,7 +101,8 @@ export function boot(
   const componentRemoteToLocal: Dict<Component[]> = {}
 
   const theme = 'dark'
-  const color = themeColor(theme)
+  const personality: Personality = DEFAULT_PERSONALITY
+  const color = themeColor(theme, PERSONALITY_PROFILES[personality])
 
   const system: System = {
     path,
@@ -105,6 +111,7 @@ export function boot(
     root: (parent && parent.root) || null,
     color,
     theme,
+    personality,
     customEvent,
     async: ASYNC,
     input,
@@ -155,6 +162,14 @@ export function boot(
     shouldFork: shouldFork.bind(registry),
     lockSpec: lockSpec.bind(registry),
     unlockSpec: unlockSpec.bind(registry),
+    setPersonality: (p: Personality): void => {
+      system.personality = p
+      system.color = themeColor(system.theme, PERSONALITY_PROFILES[p])
+      api.personality?.setPersonality(p)
+    },
+    getPersonality: (): Personality => {
+      return system.personality
+    },
     getLocalComponents: function (remoteGlobalId: string): Component[] {
       const components = componentRemoteToLocal[remoteGlobalId]
 

--- a/src/client/personality.ts
+++ b/src/client/personality.ts
@@ -1,0 +1,15 @@
+export type Personality = 'neutral' | 'playful' | 'serious'
+
+export interface PersonalityProfile {
+  baseColor?: string
+  scalar?: number
+}
+
+export const PERSONALITY_PROFILES: Record<Personality, PersonalityProfile> = {
+  neutral: { baseColor: '#666666', scalar: 0 },
+  playful: { baseColor: '#ff66cc', scalar: 15 },
+  serious: { baseColor: '#3355ff', scalar: -10 },
+}
+
+export const DEFAULT_PERSONALITY: Personality = 'neutral'
+export const DEFAULT_PERSONALITY_PROFILE = PERSONALITY_PROFILES[DEFAULT_PERSONALITY]

--- a/src/client/platform/none/boot.ts
+++ b/src/client/platform/none/boot.ts
@@ -20,6 +20,7 @@ import { DownloadDataOpt } from '../../../types/global/DownloadData'
 import { DownloadURLOpt } from '../../../types/global/DownloadURL'
 import { LayoutNode } from '../../LayoutNode'
 import { Theme } from '../../theme'
+import { Personality } from '../../personality'
 
 export function noneApi(): API {
   const api: API = {
@@ -315,6 +316,14 @@ export function noneApi(): API {
     theme: {
       setTheme: function (theme: Theme): Promise<void> {
         throw new MethodNotImplementedError()
+      },
+    },
+    personality: {
+      setPersonality: function (personality: Personality): Promise<void> {
+        throw new MethodNotImplementedError()
+      },
+      getPersonality: function (): Personality {
+        return 'neutral'
       },
     },
     crypto: {

--- a/src/client/platform/web/api/personality.ts
+++ b/src/client/platform/web/api/personality.ts
@@ -1,0 +1,23 @@
+import { API } from '../../../../API'
+import { BootOpt } from '../../../../system'
+import { Personality } from '../../../personality'
+
+export function webPersonality(
+  window: Window,
+  root: HTMLElement,
+  opt: BootOpt
+): API['personality'] {
+  let current: Personality = 'neutral'
+
+  const personality: API['personality'] = {
+    setPersonality: async function (p: Personality): Promise<void> {
+      current = p
+      root.dataset.personality = p
+    },
+    getPersonality: function (): Personality {
+      return current
+    },
+  }
+
+  return personality
+}

--- a/src/client/platform/web/boot.ts
+++ b/src/client/platform/web/boot.ts
@@ -37,6 +37,7 @@ import { webSelection } from './api/selection'
 import { webSpeech } from './api/speech'
 import { webText } from './api/text'
 import { webTheme } from './api/theme'
+import { webPersonality } from './api/personality'
 import { webURI } from './api/uri'
 import { webURL } from './api/url'
 import { webWindow } from './api/window'
@@ -85,6 +86,7 @@ export function webBoot(
   const navigator = webNavigator(window, opt)
   const layout = webLayout(window, opt)
   const theme = webTheme(window, root, opt)
+  const personality = webPersonality(window, root, opt)
   const crypto = webCrypto(window, opt)
 
   const api: API = {
@@ -115,6 +117,7 @@ export function webBoot(
     window: _window,
     navigator,
     theme,
+    personality,
   }
 
   const system = boot(null, api, opt)

--- a/src/client/platform/worker/boot.ts
+++ b/src/client/platform/worker/boot.ts
@@ -20,6 +20,7 @@ import { DownloadDataOpt } from '../../../types/global/DownloadData'
 import { DownloadURLOpt } from '../../../types/global/DownloadURL'
 import { LayoutNode } from '../../LayoutNode'
 import { Theme } from '../../theme'
+import { Personality } from '../../personality'
 
 export function workerApi(): API {
   const api: API = {
@@ -315,6 +316,14 @@ export function workerApi(): API {
     theme: {
       setTheme: function (theme: Theme): Promise<void> {
         throw new MethodNotImplementedError()
+      },
+    },
+    personality: {
+      setPersonality: function (personality: Personality): Promise<void> {
+        throw new MethodNotImplementedError()
+      },
+      getPersonality: function (): Personality {
+        return 'neutral'
       },
     },
     crypto: {

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -1,6 +1,10 @@
 import { Dict } from '../types/Dict'
 import { darkenColor, lightenColor } from './color'
 import { Mode } from './mode'
+import {
+  DEFAULT_PERSONALITY_PROFILE,
+  PersonalityProfile,
+} from './personality'
 
 export type Theme = 'light' | 'dark'
 
@@ -121,8 +125,16 @@ export const getThemeLinkModeColor = (theme: string, mode: Mode): string => {
 const DARK_DEFAULT_COLOR = '#f1f1f1'
 const LIGHT_DEFAULT_COLOR = '#1f1f1f'
 
-export const themeColor = (theme: Theme): string => {
-  return theme === 'dark' ? DARK_DEFAULT_COLOR : LIGHT_DEFAULT_COLOR
+export const themeColor = (
+  theme: Theme,
+  personality: PersonalityProfile = DEFAULT_PERSONALITY_PROFILE
+): string => {
+  const base = personality.baseColor ?? (theme === 'dark'
+      ? DARK_DEFAULT_COLOR
+      : LIGHT_DEFAULT_COLOR)
+  const factor = personality.scalar ?? 0
+
+  return applyTheme(theme, base, factor)
 }
 
 export const themeBackgroundColor = (theme: Theme): string => {

--- a/src/system.ts
+++ b/src/system.ts
@@ -15,6 +15,7 @@ import { IOElement } from './client/IOElement'
 import { Context } from './client/context'
 import { UnitPointerEvent } from './client/event/pointer'
 import { Theme } from './client/theme'
+import { Personality } from './client/personality'
 import { Point } from './client/util/geometry/types'
 import { AllTypes } from './interface'
 import { WebSocketShape } from './system/platform/api/network/WebSocket'
@@ -33,6 +34,7 @@ export interface System extends S, Registry {
   customEvent: Set<string>
   context: Context[]
   theme: Theme
+  personality: Personality
   color: string
   async: AllTypes<(unit: any) => any>
   cache: {


### PR DESCRIPTION
## Summary
- add `PersonalityProfile` descriptions
- compute theme colors based on profile scalars
- store personality in `System`
- expose personality API for web, worker and none platforms
- document how to change personality profiles

## Testing
- `npm test` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866554d37588325a5361abe55d71c4e