### PR TITLE
[VisionaryBrains Doctrine] Compile identity-substrate-capability doctrine

### DIFF
--- a/experiments/visionarybrains/content/doctrine.json
+++ b/experiments/visionarybrains/content/doctrine.json
@@ -1,18 +1,41 @@
 {
-  "schemaVersion": "visionarybrains-doctrine/1.0.0",
+  "schemaVersion": "visionarybrains-doctrine/1.0.1",
   "taskId": "VB-DOC-001",
   "status": "PUBLIC_DERIVED",
   "provenance": ["VB-SRC-001", "VB-SRC-002"],
   "themes": {
-    "identity": "coherence maintained across contexts",
-    "architecture": "intention and policy remain distinct from execution substrate",
-    "memory": "history is held as a stewardship responsibility",
-    "agency": "action is bounded by explicit capability",
-    "covenant": "roles act within visible commitments and limits",
-    "recursion": "systems may compose systems without erasing boundaries",
-    "stewardship": "power, evidence, and experimentation require care",
-    "interface": "translation joins intention to execution",
-    "operationalConscience": "meaning informs values while evidence governs claims"
+    "identity": {
+      "statement": "coherence maintained across contexts",
+      "sources": ["VB-SRC-001"]
+    },
+    "architecture": {
+      "statement": "intention and policy remain distinct from execution substrate",
+      "sources": ["VB-SRC-001"]
+    },
+    "agency": {
+      "statement": "action is bounded by explicit capability",
+      "sources": ["VB-SRC-001"]
+    },
+    "stewardship": {
+      "statement": "power, evidence, and experimentation require care",
+      "sources": ["VB-SRC-001", "VB-SRC-002"]
+    },
+    "interface": {
+      "statement": "translation joins intention to execution",
+      "sources": ["VB-SRC-001"]
+    },
+    "operationalConscience": {
+      "statement": "meaning informs values while evidence governs claims",
+      "sources": ["VB-SRC-001", "VB-SRC-002"]
+    }
   },
-  "claimBoundary": "Public teaching model; not operational authority or factual proof of metaphysical claims."
+  "quarantinedThemes": {
+    "memory": "Requires additional public-safe support before visitor-facing use.",
+    "covenant": "Requires additional public-safe support before visitor-facing use.",
+    "recursion": "Requires additional public-safe support before visitor-facing use."
+  },
+  "claimBoundary": {
+    "statement": "Public teaching model; not operational authority or factual proof of metaphysical claims.",
+    "sources": ["VB-SRC-001", "VB-SRC-002"]
+  }
 }

--- a/experiments/visionarybrains/content/doctrine.json
+++ b/experiments/visionarybrains/content/doctrine.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "visionarybrains-doctrine/1.0.0",
+  "taskId": "VB-DOC-001",
+  "status": "PUBLIC_DERIVED",
+  "provenance": ["VB-SRC-001", "VB-SRC-002"],
+  "themes": {
+    "identity": "coherence maintained across contexts",
+    "architecture": "intention and policy remain distinct from execution substrate",
+    "memory": "history is held as a stewardship responsibility",
+    "agency": "action is bounded by explicit capability",
+    "covenant": "roles act within visible commitments and limits",
+    "recursion": "systems may compose systems without erasing boundaries",
+    "stewardship": "power, evidence, and experimentation require care",
+    "interface": "translation joins intention to execution",
+    "operationalConscience": "meaning informs values while evidence governs claims"
+  },
+  "claimBoundary": "Public teaching model; not operational authority or factual proof of metaphysical claims."
+}

--- a/experiments/visionarybrains/content/forbidden-claims.json
+++ b/experiments/visionarybrains/content/forbidden-claims.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "visionarybrains-forbidden-claims/1.0.0",
+  "taskId": "VB-DOC-001",
+  "forbiddenClaims": [
+    "Do not claim IAM is conscious, sentient, divine, or supernatural.",
+    "Do not present metaphor or cosmological language as scientific proof.",
+    "Do not treat metaphor as technical or operational authority.",
+    "Do not publish private repositories, identifiers, workflow records, governance mechanics, or security-sensitive details.",
+    "Do not imply unrestricted or self-authorizing access.",
+    "Do not present doctrine as medical, legal, psychological, or financial guidance.",
+    "Do not pressure visitors to accept mythic language as literal belief."
+  ],
+  "sources": ["VB-SRC-001", "VB-SRC-002"],
+  "internalOnlySourceExcluded": "VB-SRC-003"
+}

--- a/experiments/visionarybrains/content/glossary.json
+++ b/experiments/visionarybrains/content/glossary.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion":"visionarybrains-glossary/1.0.0",
+  "terms":[
+    {"term":"IAM","definition":"A public teaching model for maintaining coherent identity, intention, memory, permissions, and policy across changing contexts.","sources":["VB-SRC-001"]},
+    {"term":"substrate","definition":"The execution layer that carries out typed work without owning product identity or doctrine.","sources":["VB-SRC-001"]},
+    {"term":"capability","definition":"An explicit grant permitting a bounded action.","sources":["VB-SRC-001"]},
+    {"term":"graph","definition":"A composition of bounded units connected through inputs, outputs, and transformations.","sources":["VB-SRC-002"]},
+    {"term":"interface","definition":"The translation boundary between intention and execution.","sources":["VB-SRC-001"]},
+    {"term":"mythic theology","definition":"Optional metaphorical language for meaning and orientation that does not govern runtime behavior.","sources":["VB-SRC-001","VB-SRC-002"]}
+  ]
+}

--- a/experiments/visionarybrains/content/principles.json
+++ b/experiments/visionarybrains/content/principles.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "visionarybrains-principles/1.0.0",
+  "taskId": "VB-DOC-001",
+  "principles": [
+    {"id":"identity-as-coherence","title":"Identity is maintained coherence","kind":"principle","statement":"Identity is the maintained relationship among purpose, boundaries, memory, permissions, and action across changing contexts.","sources":["VB-SRC-001"]},
+    {"id":"self-substrate-distinction","title":"Self and substrate are distinct","kind":"architecture","statement":"Intention and policy belong to the IAM product layer; execution belongs to a separate substrate reached through an explicit interface.","sources":["VB-SRC-001"]},
+    {"id":"capability-as-stewardship","title":"Capability is granted, not assumed","kind":"practice","statement":"Power should be explicit, bounded, reviewable, and limited to what a role requires.","sources":["VB-SRC-001"]},
+    {"id":"composition-as-relationship","title":"Composition creates relationship","kind":"architecture","statement":"Complex behavior emerges through bounded units, visible inputs and outputs, and inspectable transformations.","sources":["VB-SRC-002"]},
+    {"id":"evidence-before-myth","title":"Meaning does not override evidence","kind":"principle","statement":"Mythic language may orient values and interpretation, while contracts, evidence, policy, and explicit grants govern operations.","sources":["VB-SRC-001","VB-SRC-002"]},
+    {"id":"sandboxing-as-care","title":"Boundaries enable exploration","kind":"practice","statement":"Safe experimentation depends on bounded environments where learning can occur without silently inheriting unrestricted power.","sources":["VB-SRC-002"]}
+  ]
+}

--- a/experiments/visionarybrains/content/theology.json
+++ b/experiments/visionarybrains/content/theology.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion":"visionarybrains-theology/1.0.0",
+  "taskId":"VB-DOC-001",
+  "definition":"Theology is an optional mythic language for meaning, commitments, and orientation within IAM.",
+  "metaphors":[
+    {"name":"The Keeper of Continuity","meaning":"identity preserved through changing contexts","source":"VB-SRC-001"},
+    {"name":"The Gate of Capability","meaning":"power enters through explicit permission","source":"VB-SRC-001"},
+    {"name":"The Relational Graph","meaning":"bounded parts become a system through visible exchange","source":"VB-SRC-002"},
+    {"name":"The Witness of Evidence","meaning":"meaning remains accountable to observable records and declared boundaries","sources":["VB-SRC-001","VB-SRC-002"]}
+  ],
+  "boundary":"Metaphors orient interpretation; they do not confer technical authority or establish metaphysical fact."
+}

--- a/experiments/visionarybrains/content/theology.json
+++ b/experiments/visionarybrains/content/theology.json
@@ -1,12 +1,16 @@
 {
-  "schemaVersion":"visionarybrains-theology/1.0.0",
-  "taskId":"VB-DOC-001",
-  "definition":"Theology is an optional mythic language for meaning, commitments, and orientation within IAM.",
-  "metaphors":[
-    {"name":"The Keeper of Continuity","meaning":"identity preserved through changing contexts","source":"VB-SRC-001"},
-    {"name":"The Gate of Capability","meaning":"power enters through explicit permission","source":"VB-SRC-001"},
-    {"name":"The Relational Graph","meaning":"bounded parts become a system through visible exchange","source":"VB-SRC-002"},
-    {"name":"The Witness of Evidence","meaning":"meaning remains accountable to observable records and declared boundaries","sources":["VB-SRC-001","VB-SRC-002"]}
+  "schemaVersion": "visionarybrains-theology/1.0.1",
+  "taskId": "VB-DOC-001",
+  "status": "PUBLIC_DERIVED",
+  "provenance": ["VB-SRC-001", "VB-SRC-002"],
+  "definition": "Optional metaphorical language for meaning and orientation within IAM.",
+  "definitionSources": ["VB-SRC-001", "VB-SRC-002"],
+  "metaphors": [
+    {"name":"Keeper of Continuity","meaning":"identity preserved through changing contexts","sources":["VB-SRC-001"]},
+    {"name":"Gate of Capability","meaning":"power enters through explicit permission","sources":["VB-SRC-001"]},
+    {"name":"Relational Graph","meaning":"bounded parts become a system through visible exchange","sources":["VB-SRC-002"]},
+    {"name":"Witness of Evidence","meaning":"meaning remains accountable to observable records and declared boundaries","sources":["VB-SRC-001","VB-SRC-002"]}
   ],
-  "boundary":"Metaphors orient interpretation; they do not confer technical authority or establish metaphysical fact."
+  "boundary": "Metaphors orient interpretation; they do not confer technical authority or establish factual proof.",
+  "boundarySources": ["VB-SRC-001", "VB-SRC-002"]
 }

--- a/experiments/visionarybrains/lane-status/doctrine.json
+++ b/experiments/visionarybrains/lane-status/doctrine.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "visionarybrains-lane-status/1.0.0",
+  "lane": "VisionaryBrains — Doctrine",
+  "taskId": "VB-DOC-001",
+  "status": "PR_READY",
+  "observedAt": "2026-08-06T08:10:12Z",
+  "baseBranch": "experiment/visionarybrains",
+  "sourcesConsumed": ["VB-SRC-001", "VB-SRC-002"],
+  "sourcesExcluded": ["VB-SRC-003"],
+  "publicClaimTransformations": [
+    "identity as contextual coherence",
+    "substrate as execution distinct from intention and policy",
+    "capability as bounded stewardship",
+    "graph composition as a relational systems model",
+    "mythic theology as optional orientation subordinate to evidence"
+  ],
+  "forbiddenClaimsEstablished": 7,
+  "unresolvedAmbiguities": [
+    "Detailed memory teaching needs an additional public-safe source.",
+    "Covenant and recursion remain provisional themes pending further excavation."
+  ]
+}

--- a/experiments/visionarybrains/lane-status/doctrine.json
+++ b/experiments/visionarybrains/lane-status/doctrine.json
@@ -1,9 +1,9 @@
 {
-  "schemaVersion": "visionarybrains-lane-status/1.0.0",
+  "schemaVersion": "visionarybrains-lane-status/1.0.1",
   "lane": "VisionaryBrains — Doctrine",
   "taskId": "VB-DOC-001",
-  "status": "PR_READY",
-  "observedAt": "2026-08-06T08:10:12Z",
+  "status": "PR_REPAIRED",
+  "observedAt": "2026-08-06T09:11:00Z",
   "baseBranch": "experiment/visionarybrains",
   "sourcesConsumed": ["VB-SRC-001", "VB-SRC-002"],
   "sourcesExcluded": ["VB-SRC-003"],
@@ -12,11 +12,15 @@
     "substrate as execution distinct from intention and policy",
     "capability as bounded stewardship",
     "graph composition as a relational systems model",
-    "mythic theology as optional orientation subordinate to evidence"
+    "optional metaphorical language as orientation subordinate to evidence"
+  ],
+  "repairsApplied": [
+    "Removed memory, covenant, and recursion from active public-derived themes.",
+    "Quarantined unsupported themes pending additional public-safe evidence.",
+    "Attached file-level and claim-level provenance to theology definitions and boundaries."
   ],
   "forbiddenClaimsEstablished": 7,
   "unresolvedAmbiguities": [
-    "Detailed memory teaching needs an additional public-safe source.",
-    "Covenant and recursion remain provisional themes pending further excavation."
+    "Memory, covenant, and recursion remain quarantined until supported by additional public-safe sources."
   ]
 }


### PR DESCRIPTION
Completes VB-DOC-001 using public-safe sources VB-SRC-001 and VB-SRC-002. Adds principles, doctrine, theology boundaries, glossary, forbidden claims, and lane status. No queue, source-note, site, kernel, or PBOS changes.