### PR TITLE
[VisionaryBrains Doctrine] Compile memory stewardship and bounded recursion doctrine

### DIFF
--- a/experiments/visionarybrains/content/doctrine.json
+++ b/experiments/visionarybrains/content/doctrine.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": "visionarybrains-doctrine/1.0.1",
-  "taskId": "VB-DOC-001",
+  "schemaVersion": "visionarybrains-doctrine/1.1.0",
+  "taskId": "VB-DOC-002",
   "status": "PUBLIC_DERIVED",
-  "provenance": ["VB-SRC-001", "VB-SRC-002"],
+  "provenance": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004"],
   "themes": {
     "identity": {
       "statement": "coherence maintained across contexts",
@@ -16,26 +16,32 @@
       "statement": "action is bounded by explicit capability",
       "sources": ["VB-SRC-001"]
     },
+    "memory": {
+      "statement": "accountable continuity linking stable structure, changing state, and recoverable sequence",
+      "sources": ["VB-SRC-004"]
+    },
+    "recursion": {
+      "statement": "bounded return with preserved conditions for restoration, revision, and continuation",
+      "sources": ["VB-SRC-004"]
+    },
     "stewardship": {
-      "statement": "power, evidence, and experimentation require care",
-      "sources": ["VB-SRC-001", "VB-SRC-002"]
+      "statement": "power, evidence, memory, and experimentation require care",
+      "sources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004"]
     },
     "interface": {
       "statement": "translation joins intention to execution",
       "sources": ["VB-SRC-001"]
     },
     "operationalConscience": {
-      "statement": "meaning informs values while evidence governs claims",
-      "sources": ["VB-SRC-001", "VB-SRC-002"]
+      "statement": "meaning may orient values while ordered evidence and explicit conditions govern public claims",
+      "sources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004"]
     }
   },
   "quarantinedThemes": {
-    "memory": "Requires additional public-safe support before visitor-facing use.",
-    "covenant": "Requires additional public-safe support before visitor-facing use.",
-    "recursion": "Requires additional public-safe support before visitor-facing use."
+    "covenant": "Unsupported as a public doctrine term. Continuity and responsibility do not establish covenant without a separate public-safe source."
   },
   "claimBoundary": {
-    "statement": "Public teaching model; not operational authority or factual proof of metaphysical claims.",
-    "sources": ["VB-SRC-001", "VB-SRC-002"]
+    "statement": "Public teaching model; not operational authority, proof of metaphysical claims, or a claim that stored state reproduces personhood or consciousness.",
+    "sources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004"]
   }
 }

--- a/experiments/visionarybrains/content/forbidden-claims.json
+++ b/experiments/visionarybrains/content/forbidden-claims.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": "visionarybrains-forbidden-claims/1.0.0",
-  "taskId": "VB-DOC-001",
+  "schemaVersion": "visionarybrains-forbidden-claims/1.1.0",
+  "taskId": "VB-DOC-002",
   "forbiddenClaims": [
     "Do not claim IAM is conscious, sentient, divine, or supernatural.",
     "Do not present metaphor or cosmological language as scientific proof.",
@@ -8,8 +8,12 @@
     "Do not publish private repositories, identifiers, workflow records, governance mechanics, or security-sensitive details.",
     "Do not imply unrestricted or self-authorizing access.",
     "Do not present doctrine as medical, legal, psychological, or financial guidance.",
-    "Do not pressure visitors to accept mythic language as literal belief."
+    "Do not pressure visitors to accept mythic language as literal belief.",
+    "Do not claim stored state, snapshots, or replay constitute a person, soul, or consciousness.",
+    "Do not claim deterministic replay when external effects or conditions were not recorded.",
+    "Do not treat canonical hashes or snapshots as moral, legal, or spiritual identity.",
+    "Do not infer covenant from continuity, responsibility, memory, or recursion alone."
   ],
-  "sources": ["VB-SRC-001", "VB-SRC-002"],
+  "sources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004"],
   "internalOnlySourceExcluded": "VB-SRC-003"
 }

--- a/experiments/visionarybrains/content/glossary.json
+++ b/experiments/visionarybrains/content/glossary.json
@@ -1,11 +1,15 @@
 {
-  "schemaVersion":"visionarybrains-glossary/1.0.0",
+  "schemaVersion":"visionarybrains-glossary/1.1.0",
   "terms":[
     {"term":"IAM","definition":"A public teaching model for maintaining coherent identity, intention, memory, permissions, and policy across changing contexts.","sources":["VB-SRC-001"]},
     {"term":"substrate","definition":"The execution layer that carries out typed work without owning product identity or doctrine.","sources":["VB-SRC-001"]},
     {"term":"capability","definition":"An explicit grant permitting a bounded action.","sources":["VB-SRC-001"]},
     {"term":"graph","definition":"A composition of bounded units connected through inputs, outputs, and transformations.","sources":["VB-SRC-002"]},
     {"term":"interface","definition":"The translation boundary between intention and execution.","sources":["VB-SRC-001"]},
+    {"term":"memory","definition":"Accountable continuity connecting identifiable structure, changing state, and recoverable sequence.","sources":["VB-SRC-004"]},
+    {"term":"evidence","definition":"An ordered account of what changed, under which conditions, and through which granted capabilities.","sources":["VB-SRC-004"]},
+    {"term":"recursion","definition":"A bounded return to prior state or structure for restoration, revision, and continuation.","sources":["VB-SRC-004"]},
+    {"term":"replayability","definition":"The ability to reproduce an execution account when relevant inputs, conditions, and external effects were recorded.","sources":["VB-SRC-004"]},
     {"term":"mythic theology","definition":"Optional metaphorical language for meaning and orientation that does not govern runtime behavior.","sources":["VB-SRC-001","VB-SRC-002"]}
   ]
 }

--- a/experiments/visionarybrains/content/principles.json
+++ b/experiments/visionarybrains/content/principles.json
@@ -1,11 +1,14 @@
 {
-  "schemaVersion": "visionarybrains-principles/1.0.0",
-  "taskId": "VB-DOC-001",
+  "schemaVersion": "visionarybrains-principles/1.1.0",
+  "taskId": "VB-DOC-002",
   "principles": [
     {"id":"identity-as-coherence","title":"Identity is maintained coherence","kind":"principle","statement":"Identity is the maintained relationship among purpose, boundaries, memory, permissions, and action across changing contexts.","sources":["VB-SRC-001"]},
     {"id":"self-substrate-distinction","title":"Self and substrate are distinct","kind":"architecture","statement":"Intention and policy belong to the IAM product layer; execution belongs to a separate substrate reached through an explicit interface.","sources":["VB-SRC-001"]},
     {"id":"capability-as-stewardship","title":"Capability is granted, not assumed","kind":"practice","statement":"Power should be explicit, bounded, reviewable, and limited to what a role requires.","sources":["VB-SRC-001"]},
     {"id":"composition-as-relationship","title":"Composition creates relationship","kind":"architecture","statement":"Complex behavior emerges through bounded units, visible inputs and outputs, and inspectable transformations.","sources":["VB-SRC-002"]},
+    {"id":"memory-as-accountable-continuity","title":"Memory is accountable continuity","kind":"principle","statement":"Memory joins identifiable structure to changing state and recoverable sequence; it is stewardship of continuity rather than a metaphysical identity claim.","sources":["VB-SRC-004"]},
+    {"id":"evidence-as-ordered-transformation","title":"Evidence preserves transformation","kind":"practice","statement":"Trustworthy accounts preserve what changed, in what order, and under which explicit conditions and capabilities.","sources":["VB-SRC-004"]},
+    {"id":"recursion-as-bounded-return","title":"Recursion is bounded return","kind":"architecture","statement":"Return is responsible when prior state, external conditions, and continuation boundaries are preserved or explicitly declared missing.","sources":["VB-SRC-004"]},
     {"id":"evidence-before-myth","title":"Meaning does not override evidence","kind":"principle","statement":"Mythic language may orient values and interpretation, while contracts, evidence, policy, and explicit grants govern operations.","sources":["VB-SRC-001","VB-SRC-002"]},
     {"id":"sandboxing-as-care","title":"Boundaries enable exploration","kind":"practice","statement":"Safe experimentation depends on bounded environments where learning can occur without silently inheriting unrestricted power.","sources":["VB-SRC-002"]}
   ]

--- a/experiments/visionarybrains/content/theology.json
+++ b/experiments/visionarybrains/content/theology.json
@@ -1,16 +1,18 @@
 {
-  "schemaVersion": "visionarybrains-theology/1.0.1",
-  "taskId": "VB-DOC-001",
+  "schemaVersion": "visionarybrains-theology/1.1.0",
+  "taskId": "VB-DOC-002",
   "status": "PUBLIC_DERIVED",
-  "provenance": ["VB-SRC-001", "VB-SRC-002"],
+  "provenance": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004"],
   "definition": "Optional metaphorical language for meaning and orientation within IAM.",
   "definitionSources": ["VB-SRC-001", "VB-SRC-002"],
   "metaphors": [
-    {"name":"Keeper of Continuity","meaning":"identity preserved through changing contexts","sources":["VB-SRC-001"]},
+    {"name":"Keeper of Continuity","meaning":"identity maintained through changing contexts","sources":["VB-SRC-001"]},
+    {"name":"Steward of Memory","meaning":"state is preserved with structure, sequence, and explicit limits","sources":["VB-SRC-004"]},
+    {"name":"Witness of Transformation","meaning":"evidence follows ordered change rather than isolated assertion","sources":["VB-SRC-004"]},
+    {"name":"Returning Path","meaning":"recursion is bounded revisitation with declared state and conditions","sources":["VB-SRC-004"]},
     {"name":"Gate of Capability","meaning":"power enters through explicit permission","sources":["VB-SRC-001"]},
-    {"name":"Relational Graph","meaning":"bounded parts become a system through visible exchange","sources":["VB-SRC-002"]},
-    {"name":"Witness of Evidence","meaning":"meaning remains accountable to observable records and declared boundaries","sources":["VB-SRC-001","VB-SRC-002"]}
+    {"name":"Relational Graph","meaning":"bounded parts become a system through visible exchange","sources":["VB-SRC-002"]}
   ],
-  "boundary": "Metaphors orient interpretation; they do not confer technical authority or establish factual proof.",
-  "boundarySources": ["VB-SRC-001", "VB-SRC-002"]
+  "boundary": "Metaphors orient interpretation; they do not confer technical authority, establish factual proof, or guarantee replay when external effects were not recorded.",
+  "boundarySources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004"]
 }

--- a/experiments/visionarybrains/lane-status/doctrine.json
+++ b/experiments/visionarybrains/lane-status/doctrine.json
@@ -1,26 +1,22 @@
 {
-  "schemaVersion": "visionarybrains-lane-status/1.0.1",
+  "schemaVersion": "visionarybrains-lane-status/1.1.0",
   "lane": "VisionaryBrains — Doctrine",
-  "taskId": "VB-DOC-001",
-  "status": "PR_REPAIRED",
-  "observedAt": "2026-08-06T09:11:00Z",
+  "taskId": "VB-DOC-002",
+  "status": "PR_OPENING",
+  "observedAt": "2026-08-06T10:10:17Z",
   "baseBranch": "experiment/visionarybrains",
-  "sourcesConsumed": ["VB-SRC-001", "VB-SRC-002"],
+  "baseCommit": "33cef7ebc1a30621bf4c285a05e59f3b3219cc4a",
+  "sourcesConsumed": ["VB-SRC-004"],
   "sourcesExcluded": ["VB-SRC-003"],
   "publicClaimTransformations": [
-    "identity as contextual coherence",
-    "substrate as execution distinct from intention and policy",
-    "capability as bounded stewardship",
-    "graph composition as a relational systems model",
-    "optional metaphorical language as orientation subordinate to evidence"
+    "memory as accountable continuity joining stable structure, changing state, and recoverable sequence",
+    "evidence as ordered transformation under explicit conditions and capabilities",
+    "recursion as bounded return for restoration, revision, and continuation",
+    "replayability as conditional on recorded inputs, external effects, and execution context"
   ],
-  "repairsApplied": [
-    "Removed memory, covenant, and recursion from active public-derived themes.",
-    "Quarantined unsupported themes pending additional public-safe evidence.",
-    "Attached file-level and claim-level provenance to theology definitions and boundaries."
-  ],
-  "forbiddenClaimsEstablished": 7,
+  "forbiddenClaimsEstablished": 11,
   "unresolvedAmbiguities": [
-    "Memory, covenant, and recursion remain quarantined until supported by additional public-safe sources."
+    "Covenant remains unsupported and quarantined.",
+    "The source is a candidate technical contract and must be presented only as bounded architectural teaching material."
   ]
 }


### PR DESCRIPTION
Implements VB-DOC-002 from PUBLIC_CANON source VB-SRC-004.

Scope:
- activates memory as accountable continuity;
- defines evidence as ordered transformation;
- defines recursion as bounded return;
- expands glossary and metaphorical teaching language;
- strengthens forbidden claims around replay, snapshots, and identity;
- keeps covenant explicitly quarantined.

All changes are confined to the Doctrine lane's owned files under `experiments/visionarybrains/`.