### PR TITLE
[VisionaryBrains Teacher] Create first-encounter visitor path

### DIFF
--- a/experiments/visionarybrains/content/lessons.json
+++ b/experiments/visionarybrains/content/lessons.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": "visionarybrains-lessons/1.0.0",
+  "taskId": "VB-TEACH-001",
+  "lessons": [
+    {
+      "id": "iam-in-one-sentence",
+      "stage": "first-encounter",
+      "title": "IAM in one sentence",
+      "summary": "IAM is a way of preserving coherent identity while intentions move through changing tools, contexts, and forms of action.",
+      "kind": "principle",
+      "sources": ["identity-as-coherence", "self-substrate-distinction"]
+    },
+    {
+      "id": "power-has-boundaries",
+      "stage": "orientation",
+      "title": "Power has boundaries",
+      "summary": "An IAM-aligned system does not assume unlimited access. Capabilities are granted explicitly, kept proportionate, and made reviewable.",
+      "kind": "practice",
+      "sources": ["capability-as-stewardship", "sandboxing-as-care"]
+    },
+    {
+      "id": "meaning-and-evidence",
+      "stage": "deepening",
+      "title": "Meaning and evidence have different jobs",
+      "summary": "Mythic language can help people interpret purpose and values. Evidence, policy, contracts, and explicit permission govern factual and operational claims.",
+      "kind": "metaphor-boundary",
+      "sources": ["evidence-before-myth"]
+    },
+    {
+      "id": "relationship-before-complexity",
+      "stage": "practice",
+      "title": "Build relationships before complexity",
+      "summary": "Complex systems become understandable when their parts, inputs, outputs, and transformations remain visible.",
+      "kind": "architecture",
+      "sources": ["composition-as-relationship"]
+    },
+    {
+      "id": "visitor-synthesis",
+      "stage": "synthesis",
+      "title": "A practical reading of IAM",
+      "summary": "IAM joins identity, bounded agency, visible relationships, stewardship, and optional mythic interpretation into one public teaching frame.",
+      "kind": "synthesis",
+      "sources": ["identity-as-coherence", "capability-as-stewardship", "composition-as-relationship", "evidence-before-myth"]
+    }
+  ]
+}

--- a/experiments/visionarybrains/content/site-copy.json
+++ b/experiments/visionarybrains/content/site-copy.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "visionarybrains-site-copy/1.0.0",
+  "taskId": "VB-TEACH-001",
+  "hero": {
+    "eyebrow": "A public introduction to the IAM ecosystem",
+    "title": "Identity that can move without losing its boundaries",
+    "summary": "VisionaryBrains explores how identity, bounded agency, visible architecture, stewardship, and meaning can coexist in a changing technological world.",
+    "primaryAction": "Begin the orientation",
+    "secondaryAction": "Read the interpretation boundary"
+  },
+  "orientation": {
+    "title": "What IAM means here",
+    "body": "IAM is presented as a design and meaning framework. It asks how purpose remains coherent, how action receives permission, how relationships stay inspectable, and how metaphor can enrich interpretation without replacing evidence."
+  },
+  "interpretationBoundary": {
+    "title": "Metaphor is invitation, not authority",
+    "body": "Mythic and cosmological language is optional. It does not establish scientific proof, religious obligation, unrestricted technical access, or operational authority."
+  },
+  "sourceNote": "Visitor teaching is derived only from public-safe source classifications and integrated doctrine objects. Private operations and sensitive implementation details are excluded."
+}

--- a/experiments/visionarybrains/content/teaching-cards.json
+++ b/experiments/visionarybrains/content/teaching-cards.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "visionarybrains-teaching-cards/1.0.0",
+  "taskId": "VB-TEACH-001",
+  "cards": [
+    {"id":"coherence","label":"Principle","title":"Coherence","front":"Identity is more than a label.","back":"It is the maintained relationship among purpose, boundaries, permissions, memory, and action.","sources":["identity-as-coherence"]},
+    {"id":"interface","label":"Architecture","title":"Interface","front":"Intention is not execution.","back":"An explicit interface translates policy and purpose into bounded action on a substrate.","sources":["self-substrate-distinction"]},
+    {"id":"capability","label":"Practice","title":"Capability","front":"Power is granted, not assumed.","back":"A role should receive only the access it needs, with boundaries that can be inspected and reviewed.","sources":["capability-as-stewardship"]},
+    {"id":"composition","label":"Architecture","title":"Composition","front":"Complexity grows from relationships.","back":"Visible units, inputs, outputs, and transformations make emergent behavior easier to understand.","sources":["composition-as-relationship"]},
+    {"id":"myth-and-evidence","label":"Interpretation","title":"Myth and evidence","front":"Meaning can orient without ruling.","back":"Metaphor may illuminate values; evidence and explicit authority govern factual and operational claims.","sources":["evidence-before-myth"]},
+    {"id":"bounded-exploration","label":"Practice","title":"Bounded exploration","front":"Safety can create freedom to learn.","back":"A bounded environment supports experimentation without silently inheriting unrestricted power.","sources":["sandboxing-as-care"]}
+  ]
+}

--- a/experiments/visionarybrains/content/teaching-cards.json
+++ b/experiments/visionarybrains/content/teaching-cards.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": "visionarybrains-teaching-cards/1.0.0",
+  "schemaVersion": "visionarybrains-teaching-cards/1.0.1",
   "taskId": "VB-TEACH-001",
   "cards": [
-    {"id":"coherence","label":"Principle","title":"Coherence","front":"Identity is more than a label.","back":"It is the maintained relationship among purpose, boundaries, permissions, memory, and action.","sources":["identity-as-coherence"]},
+    {"id":"coherence","label":"Principle","title":"Coherence","front":"Identity is more than a label.","back":"It is the maintained relationship among purpose, boundaries, permissions, memory, and action.","sources":["identity-as-coherence","memory-as-accountable-continuity"]},
     {"id":"interface","label":"Architecture","title":"Interface","front":"Intention is not execution.","back":"An explicit interface translates policy and purpose into bounded action on a substrate.","sources":["self-substrate-distinction"]},
     {"id":"capability","label":"Practice","title":"Capability","front":"Power is granted, not assumed.","back":"A role should receive only the access it needs, with boundaries that can be inspected and reviewed.","sources":["capability-as-stewardship"]},
     {"id":"composition","label":"Architecture","title":"Composition","front":"Complexity grows from relationships.","back":"Visible units, inputs, outputs, and transformations make emergent behavior easier to understand.","sources":["composition-as-relationship"]},

--- a/experiments/visionarybrains/content/visitor-paths.json
+++ b/experiments/visionarybrains/content/visitor-paths.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "visionarybrains-visitor-paths/1.0.0",
+  "taskId": "VB-TEACH-001",
+  "paths": [
+    {
+      "id": "first-encounter-path",
+      "title": "Begin with IAM",
+      "audience": "Visitors with no prior IAM ecosystem knowledge",
+      "steps": [
+        {"order": 1, "stage": "first-encounter", "lessonId": "iam-in-one-sentence", "prompt": "What remains coherent when tools and contexts change?"},
+        {"order": 2, "stage": "orientation", "lessonId": "power-has-boundaries", "prompt": "What may this part of the system actually do?"},
+        {"order": 3, "stage": "deepening", "lessonId": "meaning-and-evidence", "prompt": "Is this statement metaphor, principle, architecture, or operational fact?"},
+        {"order": 4, "stage": "practice", "lessonId": "relationship-before-complexity", "prompt": "Can the inputs, outputs, and transformations be seen?"},
+        {"order": 5, "stage": "synthesis", "lessonId": "visitor-synthesis", "prompt": "How do identity, agency, stewardship, and meaning fit together?"}
+      ],
+      "completion": "The visitor can explain IAM without invoking private operations, unrestricted agency, or literal metaphysical proof."
+    }
+  ]
+}

--- a/experiments/visionarybrains/lane-status/teacher.json
+++ b/experiments/visionarybrains/lane-status/teacher.json
@@ -1,14 +1,23 @@
 {
-  "schemaVersion": "visionarybrains-lane-status/1.0.0",
+  "schemaVersion": "visionarybrains-lane-status/1.0.1",
   "lane": "VisionaryBrains — Teacher",
   "taskId": "VB-TEACH-001",
-  "status": "PR_READY",
+  "status": "PR_READY_REPAIRED",
   "baseBranch": "experiment/visionarybrains",
-  "baseCommit": "c076aec9f26fb0b2ea47ea5aec4171dc1fa97ac0",
+  "baseCommit": "9313d54854d251e73c0e102d73f405ba9bce5497",
   "doctrineConsumed": [
-    "content/principles.json",
-    "content/doctrine.json",
+    "content/principles.json@visionarybrains-principles/1.1.0",
+    "content/doctrine.json@visionarybrains-doctrine/1.1.0",
     "content/forbidden-claims.json"
+  ],
+  "doctrineObjectsConsumed": [
+    "identity-as-coherence",
+    "self-substrate-distinction",
+    "capability-as-stewardship",
+    "composition-as-relationship",
+    "memory-as-accountable-continuity",
+    "evidence-before-myth",
+    "sandboxing-as-care"
   ],
   "lessonsAdded": [
     "iam-in-one-sentence",
@@ -26,8 +35,11 @@
     "The learning path uses ordered stages and question prompts",
     "No lesson depends on animation, sound, color, or specialist notation"
   ],
+  "repairRecord": {
+    "reason": "Integrate found a memory reference without declared VB-DOC-002 consumption.",
+    "change": "The coherence card now cites memory-as-accountable-continuity and this status records the integrated memory doctrine explicitly."
+  },
   "unresolvedRisks": [
-    "Memory and bounded recursion from VB-DOC-002 are not consumed until PR 28 is integrated",
     "Covenant remains unsupported and absent from visitor teaching",
     "Builder must validate JSON shape and rendered reading order"
   ],

--- a/experiments/visionarybrains/lane-status/teacher.json
+++ b/experiments/visionarybrains/lane-status/teacher.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "visionarybrains-lane-status/1.0.0",
+  "lane": "VisionaryBrains — Teacher",
+  "taskId": "VB-TEACH-001",
+  "status": "PR_READY",
+  "baseBranch": "experiment/visionarybrains",
+  "baseCommit": "c076aec9f26fb0b2ea47ea5aec4171dc1fa97ac0",
+  "doctrineConsumed": [
+    "content/principles.json",
+    "content/doctrine.json",
+    "content/forbidden-claims.json"
+  ],
+  "lessonsAdded": [
+    "iam-in-one-sentence",
+    "power-has-boundaries",
+    "meaning-and-evidence",
+    "relationship-before-complexity",
+    "visitor-synthesis"
+  ],
+  "audienceAssumptions": [
+    "No prior knowledge of IAM, Project Q, AlienOS, or InfiniChain",
+    "Visitors may prefer plain language before optional mythic interpretation"
+  ],
+  "accessibilityReadability": [
+    "Short summaries and explicit labels distinguish principle, architecture, practice, and metaphor",
+    "The learning path uses ordered stages and question prompts",
+    "No lesson depends on animation, sound, color, or specialist notation"
+  ],
+  "unresolvedRisks": [
+    "Memory and bounded recursion from VB-DOC-002 are not consumed until PR 28 is integrated",
+    "Covenant remains unsupported and absent from visitor teaching",
+    "Builder must validate JSON shape and rendered reading order"
+  ],
+  "publicSafety": {
+    "privateOperationalContent": "excluded",
+    "metaphysicalProofClaims": "excluded",
+    "unrestrictedAgencyClaims": "excluded",
+    "medicalLegalFinancialClaims": "excluded"
+  }
+}


### PR DESCRIPTION
Implements VB-TEACH-001 from the integrated public-safe doctrine foundation.

Scope:
- creates a five-stage visitor path: first encounter, orientation, deepening, practice, synthesis;
- adds plain-language lessons and teaching cards;
- distinguishes principle, architecture, practice, and metaphor;
- adds visitor-facing hero, orientation, interpretation boundary, and source note;
- excludes private operations, unrestricted agency, literal metaphysical proof, and unsupported covenant claims.

Repair applied after Integrate review:
- consumes integrated VB-DOC-002 memory doctrine;
- maps the coherence card's memory language to `memory-as-accountable-continuity`;
- corrects the Teacher lane-status provenance and base commit.

All changes remain confined to Teacher-owned files under `experiments/visionarybrains/`. Covenant remains quarantined.