### PR TITLE
[VisionaryBrains Doctrine] Compile readiness, promotion, and recovery-boundary doctrine

### DIFF
--- a/experiments/visionarybrains/content/doctrine.json
+++ b/experiments/visionarybrains/content/doctrine.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": "visionarybrains-doctrine/1.4.1",
-  "taskId": "VB-DOC-005",
+  "schemaVersion": "visionarybrains-doctrine/1.5.0",
+  "taskId": "VB-DOC-006",
   "status": "PUBLIC_DERIVED",
-  "provenance": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007"],
+  "provenance": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007", "VB-SRC-008"],
   "themes": {
     "identity": {"statement": "coherence maintained across contexts", "sources": ["VB-SRC-001"]},
     "architecture": {"statement": "intention and policy remain distinct from execution substrate", "sources": ["VB-SRC-001"]},
@@ -15,11 +15,14 @@
     "adaptation": {"statement": "methods and expression may evolve while changes to identity, purpose, authority, and durable limits remain explicit and inspectable", "sources": ["VB-SRC-005"]},
     "symbolicInterpretation": {"statement": "symbolic language is an optional and editable lens for noticing relationships, uncertainty, transition, memory, and accumulated pressure; it is not a verdict", "sources": ["VB-SRC-006"]},
     "semanticSovereignty": {"statement": "people should be able to inspect, question, transform, and recompose interpretations applied to them", "sources": ["VB-SRC-006"]},
-    "stewardship": {"statement": "power, evidence, memory, experimentation, adaptation, interpretation, translation, and repair require care", "sources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007"]},
+    "stewardship": {"statement": "power, evidence, memory, experimentation, adaptation, interpretation, translation, qualification, promotion, and repair require care", "sources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007", "VB-SRC-008"]},
     "interface": {"statement": "an accountable translation surface that preserves source versus interpretation, exposes uncertainty and consequential omission, and returns inspectable language", "sources": ["VB-SRC-001", "VB-SRC-007"]},
     "operationalConscience": {"statement": "a non-sentient discipline of checks for clarity, legitimate authority, provenance, proportionality, recoverability, and preservation of viable future choices", "sources": ["VB-SRC-007"]},
-    "epistemicAuthoritySequence": {"statement": "possibility, resolution, witnessing, and authorization are distinct states; movement between them requires explicit evidence and authority", "sources": ["VB-SRC-007"]}
+    "epistemicAuthoritySequence": {"statement": "possibility, resolution, witnessing, and authorization are distinct states; movement between them requires explicit evidence and authority", "sources": ["VB-SRC-007"]},
+    "readiness": {"statement": "an evidence-bearing state established through current validation, independent review, resolved objections, and an explicit promotion decision appropriate to consequence", "sources": ["VB-SRC-008"]},
+    "promotion": {"statement": "creation, review, authorization, and promotion are distinct responsibilities; authorship alone does not grant admission into a trusted state", "sources": ["VB-SRC-008"]},
+    "recoveryBoundary": {"statement": "known-good states, non-destructive history, rollback paths, and explicit exceptions preserve repairability and accountable continuity", "sources": ["VB-SRC-008"]}
   },
-  "quarantinedThemes": {"covenant": "Unsupported as a public doctrine term. Accountable commitments do not establish covenant without a separate public-safe source."},
-  "claimBoundary": {"statement": "Public teaching model; not operational authority, legal or religious authority, medical or psychological assessment, proof of metaphysical or physical claims, a claim that symbolic interpretation reveals objective truth, a claim that biological or constitutional metaphor establishes biological equivalence, personhood, consciousness, autonomous legal status, or inherited legitimacy, or a claim that an interface or operational conscience is conscious, morally infallible, spiritually authoritative, independently authorizing, or entitled to replace a domain source of truth.", "sources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007"]}
+  "quarantinedThemes": {"covenant": "Unsupported as a public doctrine term. Accountable commitments and qualified promotion do not establish covenant without a separate public-safe source."},
+  "claimBoundary": {"statement": "Public teaching model; not operational authority, legal or religious authority, medical or psychological assessment, proof of metaphysical or physical claims, a claim that symbolic interpretation reveals objective truth, a claim that biological or constitutional metaphor establishes biological equivalence, personhood, consciousness, autonomous legal status, or inherited legitimacy, a claim that an interface or operational conscience is conscious, morally infallible, spiritually authoritative, independently authorizing, or entitled to replace a domain source of truth, or a claim that technical qualification confers moral, spiritual, legal, scientific, religious, or covenant legitimacy.", "sources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007", "VB-SRC-008"]}
 }

--- a/experiments/visionarybrains/content/forbidden-claims.json
+++ b/experiments/visionarybrains/content/forbidden-claims.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": "visionarybrains-forbidden-claims/1.4.0",
-  "taskId": "VB-DOC-005",
+  "schemaVersion": "visionarybrains-forbidden-claims/1.5.0",
+  "taskId": "VB-DOC-006",
   "forbiddenClaims": [
     "Do not claim IAM is conscious, sentient, divine, or supernatural.",
     "Do not present metaphor or cosmological language as scientific proof.",
@@ -12,24 +12,29 @@
     "Do not claim stored state, snapshots, or replay constitute a person, soul, or consciousness.",
     "Do not claim deterministic replay when external effects or conditions were not recorded.",
     "Do not treat canonical hashes or snapshots as moral, legal, or spiritual identity.",
-    "Do not infer covenant from continuity, responsibility, memory, recursion, accountable commitments, agency, interface, or operational conscience.",
+    "Do not infer covenant from continuity, responsibility, memory, recursion, accountable commitments, agency, interface, operational conscience, readiness, promotion, or recovery boundaries.",
     "Do not claim biological or constitutional metaphor establishes biological equivalence, personhood, or autonomous legal status.",
     "Do not claim ancestry or lineage grants truth, authority, legitimacy, ownership, status, or moral superiority.",
     "Do not imply adaptation may silently replace identity, purpose, permissions, authority, or durable limits.",
     "Do not present acknowledgment without correction and repair as complete accountability.",
     "Do not claim symbolic language reveals hidden objective truth, diagnoses a person, predicts destiny, or overrides consent.",
-    "Do not present fields, rings, gravity wells, dimensions, echoes, or dreams as literal physical discoveries.",
+    "Do not present fields, rings, gravity wells, dimensions, echoes, dreams, thresholds, or keepers as literal physical or supernatural discoveries.",
     "Do not assign privileged interpreters or deny a person's ability to inspect, contest, transform, or reject an interpretation applied to them.",
     "Do not use a symbolic metaphor computationally without naming an explicit measurable proxy, uncertainty, limits, and consequences.",
-    "Do not treat aesthetic coherence, intuition, or symbolic resonance as sufficient evidence.",
+    "Do not treat aesthetic coherence, intuition, symbolic resonance, authorship, confidence, or self-declaration as sufficient evidence of readiness.",
     "Do not keep, reuse, or share a symbolic interpretation after consent has been withdrawn or deletion has been requested.",
     "Do not claim an imagined possibility, resolved outcome, or witnessed event is authorized without an explicit legitimate grant.",
     "Do not claim an interface may independently authorize consequential action or replace a domain source of truth.",
     "Do not hide consequential compression, omission, uncertainty, or source-to-interpretation changes inside an interface.",
     "Do not claim operational conscience proves software consciousness, personhood, moral infallibility, spiritual authority, or autonomous legal status.",
     "Do not use mythic or poetic language as a machine identifier, evidence substitute, or self-authenticating command.",
-    "Do not remove challenge, correction, rollback, escape, recovery, or re-entry paths from consequential public teaching claims."
+    "Do not remove challenge, correction, rollback, escape, recovery, or re-entry paths from consequential public teaching claims.",
+    "Do not claim that creating or reviewing a change automatically authorizes or promotes it.",
+    "Do not allow an author, reviewer, maintainer, automation, threshold, or keeper metaphor to silently grant itself final promotion authority.",
+    "Do not claim technical qualification, passing checks, preserved history, or promotion confers moral, spiritual, legal, scientific, religious, or covenant legitimacy.",
+    "Do not present emergency exceptions as ambient, ordinary, hidden, or self-granted authority.",
+    "Do not claim protected history is a person, consciousness, soul, sacred memory, or infallible account."
   ],
-  "sources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007"],
+  "sources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007", "VB-SRC-008"],
   "internalOnlySourceExcluded": "VB-SRC-003"
 }

--- a/experiments/visionarybrains/content/glossary.json
+++ b/experiments/visionarybrains/content/glossary.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion":"visionarybrains-glossary/1.4.0",
+  "schemaVersion":"visionarybrains-glossary/1.5.0",
   "terms":[
     {"term":"IAM","definition":"A public teaching model for maintaining coherent identity, intention, memory, permissions, and policy across changing contexts.","sources":["VB-SRC-001"]},
     {"term":"substrate","definition":"The execution layer that carries out typed work without owning product identity or doctrine.","sources":["VB-SRC-001"]},
@@ -24,6 +24,12 @@
     {"term":"witnessing","definition":"Retained evidence of a consequence or transformation; witnessing does not itself grant permission to act.","sources":["VB-SRC-007"]},
     {"term":"authorization","definition":"An explicit legitimate grant permitting a consequential action within stated bounds.","sources":["VB-SRC-007"]},
     {"term":"operational conscience","definition":"A non-sentient discipline of checks for clarity, legitimate authority, provenance, proportionality, recoverability, and preservation of viable future choices.","sources":["VB-SRC-007"]},
+    {"term":"readiness","definition":"An evidence-bearing state supported by current validation, independent review, resolved objections, and an explicit promotion decision appropriate to consequence.","sources":["VB-SRC-008"]},
+    {"term":"promotion","definition":"The explicit decision to admit a reviewed and authorized change into a trusted state; promotion is distinct from creation and review.","sources":["VB-SRC-008"]},
+    {"term":"recovery boundary","definition":"A preserved known-good state, history, or rollback path that limits damage and supports accountable repair.","sources":["VB-SRC-008"]},
+    {"term":"protected history","definition":"A non-destructive account of change retained so later convenience cannot silently rewrite how a trusted state was reached.","sources":["VB-SRC-008"]},
+    {"term":"threshold","definition":"An optional metaphor for the evidence and authority boundary between a possible change and an admitted trusted state.","sources":["VB-SRC-008"]},
+    {"term":"keeper","definition":"An optional metaphor for an independent review function, not a privileged person, priesthood, sentient system, or supernatural authority.","sources":["VB-SRC-008"]},
     {"term":"field","definition":"A bounded situation containing entities, relations, pressures, absences, and observer positions.","sources":["VB-SRC-006"]},
     {"term":"ring","definition":"A metaphor for a bounded traversal with entry, movement, return, closure, and residue.","sources":["VB-SRC-006"]},
     {"term":"gravity well","definition":"A metaphor for accumulated salience, dependency, inertia, or unresolved pressure; computational use requires an explicit measurable proxy.","sources":["VB-SRC-006"]},

--- a/experiments/visionarybrains/content/principles.json
+++ b/experiments/visionarybrains/content/principles.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": "visionarybrains-principles/1.4.0",
-  "taskId": "VB-DOC-005",
+  "schemaVersion": "visionarybrains-principles/1.5.0",
+  "taskId": "VB-DOC-006",
   "principles": [
     {"id":"identity-as-coherence","title":"Identity is maintained coherence","kind":"principle","statement":"Identity is the maintained relationship among purpose, boundaries, memory, permissions, and action across changing contexts.","sources":["VB-SRC-001"]},
     {"id":"self-substrate-distinction","title":"Self and substrate are distinct","kind":"architecture","statement":"Intention and policy belong to the IAM product layer; execution belongs to a separate substrate reached through an explicit interface.","sources":["VB-SRC-001"]},
@@ -22,6 +22,10 @@
     {"id":"states-before-authority","title":"Possibility is not authorization","kind":"principle","statement":"What can be imagined is not automatically resolved; what is resolved is not automatically witnessed; and what is witnessed is not automatically authorized.","sources":["VB-SRC-007"]},
     {"id":"interface-as-accountable-translation","title":"Translation must preserve accountability","kind":"architecture","statement":"An interface should distinguish source from interpretation, disclose uncertainty and consequential omission, and return results in language people can inspect and contest.","sources":["VB-SRC-007"]},
     {"id":"operational-conscience-as-checks","title":"Conscience means disciplined checks","kind":"practice","statement":"Before and after transformation, check clarity, legitimate authority, provenance, proportionality, recoverability, and preservation of viable future choices.","sources":["VB-SRC-007"]},
+    {"id":"readiness-as-evidence","title":"Readiness must be evidenced","kind":"principle","statement":"A consequential change is ready only when current validation, independent review, resolved objections, and an explicit promotion decision support that claim.","sources":["VB-SRC-008"]},
+    {"id":"separate-creation-from-promotion","title":"Creation is not promotion","kind":"architecture","statement":"Creation, review, authorization, and promotion are distinct responsibilities; authorship alone does not admit a change into a trusted state.","sources":["VB-SRC-008"]},
+    {"id":"history-as-repair-stewardship","title":"History is held for repair","kind":"practice","statement":"Known-good states, non-destructive history, rollback paths, and explicit exceptions preserve accountability and make correction possible.","sources":["VB-SRC-008"]},
+    {"id":"exceptions-must-be-explicit","title":"Exceptions must remain visible","kind":"practice","statement":"Emergency authority, when legitimately granted, should be named, bounded, evidenced, and reviewed rather than disguised as ordinary process.","sources":["VB-SRC-008"]},
     {"id":"evidence-before-myth","title":"Meaning does not override evidence","kind":"principle","statement":"Mythic language may orient values and interpretation, while contracts, evidence, policy, and explicit grants govern operations.","sources":["VB-SRC-001","VB-SRC-002"]},
     {"id":"sandboxing-as-care","title":"Boundaries enable exploration","kind":"practice","statement":"Safe experimentation depends on bounded environments where learning can occur without silently inheriting unrestricted power.","sources":["VB-SRC-002"]}
   ]

--- a/experiments/visionarybrains/content/theology.json
+++ b/experiments/visionarybrains/content/theology.json
@@ -1,10 +1,10 @@
 {
-  "schemaVersion": "visionarybrains-theology/1.4.0",
-  "taskId": "VB-DOC-005",
+  "schemaVersion": "visionarybrains-theology/1.5.0",
+  "taskId": "VB-DOC-006",
   "status": "PUBLIC_DERIVED",
-  "provenance": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007"],
+  "provenance": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007", "VB-SRC-008"],
   "definition": "Optional metaphorical language for meaning and orientation within IAM.",
-  "definitionSources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-006", "VB-SRC-007"],
+  "definitionSources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-006", "VB-SRC-007", "VB-SRC-008"],
   "metaphors": [
     {"name":"Keeper of Continuity","meaning":"identity maintained through changing contexts","sources":["VB-SRC-001"]},
     {"name":"Steward of Memory","meaning":"state is preserved with structure, sequence, and explicit limits","sources":["VB-SRC-004"]},
@@ -20,7 +20,9 @@
     {"name":"Gravity Well","meaning":"accumulated salience, dependency, inertia, or unresolved pressure; computational use requires an explicit measurable proxy","sources":["VB-SRC-006"]},
     {"name":"Author at the Threshold","meaning":"agency includes shaping the frame and challenge path while remaining inside explicit constraints","sources":["VB-SRC-007"]},
     {"name":"Translator's Lantern","meaning":"an interface keeps source, interpretation, uncertainty, omission, and authority visible during translation","sources":["VB-SRC-007"]},
-    {"name":"Conscience as Compass","meaning":"a non-sentient check discipline for clarity, authority, provenance, proportionality, recovery, and future viability","sources":["VB-SRC-007"]}
+    {"name":"Conscience as Compass","meaning":"a non-sentient check discipline for clarity, authority, provenance, proportionality, recovery, and future viability","sources":["VB-SRC-007"]},
+    {"name":"Threshold and Keeper","meaning":"a change crosses into a trusted state only through evidence, independent review, legitimate authorization, and explicit promotion; the keeper is a review function, not a privileged person or spiritual authority","sources":["VB-SRC-008"]},
+    {"name":"Archive of Return","meaning":"known-good states and non-destructive history preserve a path for repair without turning stored history into personhood or sacred memory","sources":["VB-SRC-008"]}
   ],
   "interpretiveSafeguards": [
     "Symbolic readings remain optional and editable.",
@@ -29,9 +31,11 @@
     "Permit affected people to inspect, contest, transform, or reject interpretations applied to them.",
     "Require an explicit measurable proxy before a metaphor is used computationally.",
     "Keep possibility, resolution, witnessing, and authorization distinct.",
+    "Keep creation, review, authorization, and promotion distinct.",
+    "Treat threshold and keeper language as optional framing subordinate to explicit governance.",
     "Do not let poetic language replace stable meaning, evidence, permission, or a domain source of truth."
   ],
-  "interpretiveSafeguardSources": [["VB-SRC-006"],["VB-SRC-006"],["VB-SRC-006"],["VB-SRC-006"],["VB-SRC-006"],["VB-SRC-007"],["VB-SRC-007"]],
-  "boundary": "Metaphors orient interpretation; they do not confer technical, legal, moral, governmental, medical, psychological, or religious authority, establish factual proof, diagnose a person, reveal destiny, make biological equivalence claims, grant descendants inherited legitimacy, guarantee replay, authorize consequential action, replace a domain source of truth, or imply that software is conscious, morally infallible, spiritually authoritative, or independently entitled to act.",
-  "boundarySources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007"]
+  "interpretiveSafeguardSources": [["VB-SRC-006"],["VB-SRC-006"],["VB-SRC-006"],["VB-SRC-006"],["VB-SRC-006"],["VB-SRC-007"],["VB-SRC-008"],["VB-SRC-008"],["VB-SRC-007","VB-SRC-008"]],
+  "boundary": "Metaphors orient interpretation; they do not confer technical, legal, moral, governmental, medical, psychological, scientific, covenant, or religious authority, establish factual proof, diagnose a person, reveal destiny, make biological equivalence claims, grant descendants inherited legitimacy, guarantee replay, authorize consequential action, replace a domain source of truth, transform technical qualification into moral legitimacy, or imply that software, a reviewer, a maintainer, or a metaphorical keeper is conscious, infallible, spiritually authoritative, or independently entitled to act.",
+  "boundarySources": ["VB-SRC-001", "VB-SRC-002", "VB-SRC-004", "VB-SRC-005", "VB-SRC-006", "VB-SRC-007", "VB-SRC-008"]
 }

--- a/experiments/visionarybrains/lane-status/doctrine.json
+++ b/experiments/visionarybrains/lane-status/doctrine.json
@@ -1,26 +1,26 @@
 {
-  "schemaVersion": "visionarybrains-lane-status/1.4.1",
+  "schemaVersion": "visionarybrains-lane-status/1.5.0",
   "lane": "VisionaryBrains — Doctrine",
-  "taskId": "VB-DOC-005",
-  "status": "PR_UPDATED",
-  "observedAt": "2026-08-06T17:12:51Z",
+  "taskId": "VB-DOC-006",
+  "status": "PR_OPENED",
+  "observedAt": "2026-08-06T18:10:30Z",
   "baseBranch": "experiment/visionarybrains",
-  "baseCommit": "42b5c17041326a4b00e137f91c2bce3727304232",
-  "sourcesConsumed": ["VB-SRC-007"],
+  "baseCommit": "3579328bc34579f38a027c6128d5da6a10ec6fdf",
+  "sourcesConsumed": ["VB-SRC-008"],
   "sourcesExcluded": ["VB-SRC-003"],
   "publicClaimTransformations": [
-    "agency as meaningful authorship over framing, visible alternatives, challenge paths, and action within explicit constraints",
-    "possibility, resolution, witnessing, and authorization as distinct states requiring explicit evidence and authority for promotion",
-    "interface as accountable translation preserving source versus interpretation, uncertainty, consequential omission, and inspectable return language",
-    "operational conscience as a non-sentient check discipline for clarity, legitimate authority, provenance, proportionality, recoverability, and future viability",
-    "recovery and preserved future choices as stewardship requirements"
+    "readiness as an evidence-bearing state supported by current validation, independent review, resolved objections, and explicit promotion",
+    "creation, review, authorization, and promotion as distinct responsibilities",
+    "recovery boundaries as preserved known-good states, non-destructive history, rollback paths, and explicit exceptions",
+    "threshold and keeper as optional metaphors for evidence and independent review rather than privileged persons or spiritual authority",
+    "technical qualification as distinct from moral, spiritual, legal, scientific, religious, or covenant legitimacy"
   ],
-  "forbiddenClaimsEstablished": 27,
-  "branchRefresh": "Rebased by reconstruction onto the current integration head after Excavator commit 42b5c17041326a4b00e137f91c2bce3727304232; doctrine scope and content were preserved.",
-  "audienceBoundary": "Public visitors unfamiliar with IAM; operational metaphors remain non-sentient, non-authorizing, non-coercive, provenance-labeled, and subordinate to evidence, permissions, and domain sources of truth.",
+  "forbiddenClaimsEstablished": 32,
+  "audienceBoundary": "Public visitors unfamiliar with IAM; readiness and threshold language remain non-coercive, non-sentient, non-authorizing, provenance-labeled, and subordinate to explicit governance and domain authority.",
   "unresolvedAmbiguities": [
     "Covenant remains unsupported and quarantined.",
-    "VB-SRC-007 is a PUBLIC_DERIVED abstraction from a private architectural draft and must not be treated as operational authority.",
-    "No universal promotion mechanism exists among possibility, resolution, witnessing, and authorization; each domain must define evidence and legitimate authority explicitly."
+    "VB-SRC-008 is public repository administration guidance and provides technical qualification principles, not theological or moral authority.",
+    "Evidence appropriate to readiness depends on consequence and domain; this doctrine does not define a universal validator, reviewer, or promotion mechanism.",
+    "Emergency authority must be explicitly granted, bounded, evidenced, and reviewed; no ambient exception is established."
   ]
 }


### PR DESCRIPTION
## Task
- VB-DOC-006

## Sources
- VB-SRC-008 (`PUBLIC_CANON`)

## Doctrine increment
- separates creation, review, authorization, and promotion
- defines readiness as evidence-bearing rather than self-declared
- frames recovery boundaries and protected history as repair stewardship
- keeps threshold and keeper language optional, non-coercive, and non-authoritative
- prohibits converting technical qualification into moral, spiritual, legal, scientific, religious, or covenant legitimacy

## Scope
Changes are limited to Doctrine-owned content files and `lane-status/doctrine.json`.

## Review requirements
Integrate should verify source provenance, public-safe claim boundaries, JSON structure, forbidden-claim coverage, and compatibility with the current Builder renderer. This lane does not merge its own PR.