### PR TITLE
feat(runtime): add generic interoperability contract

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -3,6 +3,7 @@
 Authoritative post-consolidation architecture documents:
 
 - [Kernel Contract](kernel-contract.md) — graph identity, capabilities, lifecycle, events, snapshots, compatibility, and conformance.
+- [Runtime Interoperability Contract](interoperability-contract.md) — normalized external sources, portable invocation envelopes, capability grants, and generic execution evidence.
 - [Repository Boundaries](repository-boundaries.md) — admission rules and the dependency boundary between Unit and downstream products.
 
 These documents describe executable kernel policy. Speculative doctrine and product

--- a/docs/architecture/interoperability-contract.md
+++ b/docs/architecture/interoperability-contract.md
@@ -1,0 +1,119 @@
+# Runtime Interoperability Contract
+
+Status: candidate generic adapter contract for the post-consolidation kernel line.
+
+## Purpose
+
+Unit needs a stable seam between product-owned control surfaces and the portable graph
+runtime without importing product policy into the kernel. The interoperability contract
+provides that seam for normalized external sources, one-graph runtime invocations, and
+portable execution evidence.
+
+The TypeScript contract and helper are published in
+`src/runtime/interoperability.ts`.
+
+## Invocation envelope
+
+A `RuntimeInvocation` contains only execution information that is portable across hosts:
+
+- a caller-owned `requestId`;
+- the `GraphSpec` to execute;
+- normalized source descriptors used for provenance;
+- ordered input-pin pushes, optionally linked to a source descriptor;
+- output pins to consume;
+- a capability manifest describing what the graph requires or may use;
+- the capabilities already granted by the host.
+
+`runRuntimeInvocation(runtime, invocation)` validates the generic envelope, evaluates
+capabilities, executes the graph through `GraphRuntime`, verifies snapshot identity, and
+returns outputs plus a `RuntimeEvidenceManifest`.
+
+The helper is intentionally a one-graph operation. Higher-order pipelines remain outside
+the kernel and may compile their work into one graph or a sequence of invocations.
+
+## Source normalization
+
+`RuntimeSource` separates source kind from data modality.
+
+Canonical source kinds are:
+
+- `inline`
+- `file`
+- `stream`
+- `uri`
+- namespaced `extension.*` kinds
+
+Canonical modalities are:
+
+- `text`
+- `structured`
+- `image`
+- `audio`
+- `video`
+- `binary`
+- namespaced `extension.*` modalities
+
+When a modality is omitted, Unit derives it from a normalized media type. JSON and
+`+json` media types classify as `structured`; text, image, audio, and video media
+families classify directly; everything else defaults to `binary`.
+
+Source identifiers must be non-empty and unique. Normalized sources are sorted by ID so
+the evidence surface is stable regardless of intake order. Media types and supplied
+digests are normalized to lowercase; locators are trimmed but otherwise opaque to the
+kernel.
+
+Unit does not dereference locators or hash source bytes. The adapter that has access to
+the source is responsible for resolution and for supplying a digest when byte-level
+provenance is required.
+
+## Capability boundary
+
+`availableCapabilities` represents grants already resolved by the host. It is not a
+policy declaration and Unit does not decide why a capability was granted.
+
+External resources should map to existing portable capabilities such as
+`filesystem.read`, `filesystem.write`, and `network.http`, or to a namespaced
+`extension.*` capability when a host-specific operation has no canonical Unit
+capability.
+
+## Evidence manifest
+
+`RuntimeEvidenceManifest` records generic execution evidence only:
+
+- contract version;
+- request ID;
+- graph ID and canonical graph hash;
+- normalized source descriptors and caller-supplied digests;
+- requested output pin IDs;
+- snapshot graph ID, graph hash, and execution sequence.
+
+The manifest deliberately excludes product receipts, organizational identities, policy
+results, approval records, and arbitrary output serialization. Downstream systems may
+bind those records to the graph hash and snapshot sequence without changing Unit's
+kernel vocabulary.
+
+## Downstream policy boundary
+
+The following concepts are intentionally not part of this contract:
+
+- specialist or persona ownership;
+- routing presets and product-specific route names;
+- authority ceilings or organizational permission policy;
+- public/private publication classification;
+- review, approval, or release gates;
+- worker, queue, or schedule semantics;
+- higher-order stage DAGs such as `depends_on`, `reads`, and `writes` policy records.
+
+A downstream adapter may use all of those concepts while producing portable
+`RuntimeInvocation` values. The dependency direction remains product policy -> adapter
+-> Unit runtime, never the reverse.
+
+## Conformance
+
+A conforming interoperability adapter should produce equivalent normalized source
+metadata and runtime evidence for the same graph, ordered inputs, outputs, and granted
+capabilities across Node, Web, Worker, and future hosts.
+
+Repository tests cover modality classification, deterministic source normalization,
+duplicate-source rejection, source-to-pin provenance validation, capability enforcement,
+output capture, and evidence binding to snapshot identity.

--- a/docs/architecture/repository-boundaries.md
+++ b/docs/architecture/repository-boundaries.md
@@ -11,7 +11,8 @@
 - platform adapters for Web, Node, Worker, and extensions;
 - the visual graph editor and its reusable interaction foundations;
 - capability enforcement at the runtime boundary;
-- low-level execution events, snapshots, and graph identity.
+- low-level execution events, snapshots, and graph identity;
+- normalized source descriptors, portable runtime invocation envelopes, and generic execution evidence that do not encode product policy.
 
 ## Downstream responsibility
 
@@ -25,10 +26,12 @@ For FlowGPT OS and IAM, those concerns belong in `/new` or its descendants:
 - prompts, goal compilation, and synthetic forums;
 - proof bundles and product-level receipts;
 - dashboards, mission control, branding, and application navigation;
-- product-specific AI providers and business logic.
+- product-specific AI providers and business logic;
+- specialist routing presets, authority ceilings, publication boundaries, and approval or release gates.
 
-Downstream systems may translate their contracts into Unit graphs and capabilities.
-Unit must not import those product concepts into the kernel.
+Downstream systems may translate their contracts into Unit graphs, normalized runtime
+invocations, and capabilities. Unit must not import those product concepts into the
+kernel.
 
 ## Integration direction
 
@@ -41,25 +44,27 @@ product intention and policy
 product-owned Unit adapter
           |
           v
-typed graph + capability grant
+normalized sources + typed graph + capability grant
           |
           v
 Unit kernel
           |
           v
-ordered events + outputs + snapshot
+ordered outputs + events + snapshot + generic evidence
 ```
 
 A downstream adapter may:
 
+- normalize multimodal or external sources before runtime entry;
 - compile product steps into Unit graph bundles;
 - request capabilities from product policy;
-- instantiate and control graphs through `GraphRuntime`;
-- convert runtime events into product telemetry or receipts;
+- instantiate and control graphs through `GraphRuntime` or `runRuntimeInvocation`;
+- convert runtime events and generic evidence into product telemetry or receipts;
 - store graph hashes and snapshots in product provenance systems.
 
 The Unit kernel may not call back into a product policy engine or assume a specific
-worker, identity, memory, or receipt schema.
+worker, identity, memory, routing preset, authority ceiling, publication boundary, or
+receipt schema.
 
 ## Admission rule
 

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,3 +1,4 @@
 export * from './capability'
 export * from './conformance'
 export * from './contract'
+export * from './interoperability'

--- a/src/runtime/interoperability.ts
+++ b/src/runtime/interoperability.ts
@@ -1,0 +1,231 @@
+import { hashGraphSpec } from '../spec/identity'
+import { Capability, CapabilityManifest } from '../types/Capability'
+import { GraphSpec } from '../types/GraphSpec'
+import {
+  assertCapabilities,
+  normalizeCapabilityManifest,
+} from './capability'
+import {
+  GraphRuntime,
+  RuntimeGraphId,
+  RuntimeSnapshot,
+} from './contract'
+
+export type RuntimeSourceModality =
+  | 'audio'
+  | 'binary'
+  | 'image'
+  | 'structured'
+  | 'text'
+  | 'video'
+  | `extension.${string}`
+
+export type RuntimeSourceKind =
+  | 'file'
+  | 'inline'
+  | 'stream'
+  | 'uri'
+  | `extension.${string}`
+
+export type RuntimeSource = {
+  id: string
+  kind: RuntimeSourceKind
+  modality?: RuntimeSourceModality
+  mediaType?: string
+  locator?: string
+  digest?: string
+}
+
+export type RuntimeInvocationInput = {
+  pinId: string
+  data: unknown
+  sourceId?: string
+}
+
+export type RuntimeInvocationOutput = {
+  pinId: string
+}
+
+export type RuntimeInvocation = {
+  requestId: string
+  spec: GraphSpec
+  sources?: RuntimeSource[]
+  inputs?: RuntimeInvocationInput[]
+  outputs?: RuntimeInvocationOutput[]
+  manifest?: CapabilityManifest
+  availableCapabilities?: Capability[]
+}
+
+export type RuntimeEvidenceSource = {
+  id: string
+  kind: RuntimeSourceKind
+  modality: RuntimeSourceModality
+  mediaType?: string
+  locator?: string
+  digest?: string
+}
+
+export type RuntimeEvidenceManifest = {
+  version: 'unit.runtime-evidence/1'
+  requestId: string
+  graphId: RuntimeGraphId
+  graphHash: string
+  sources: RuntimeEvidenceSource[]
+  outputPins: string[]
+  snapshot: {
+    graphId: RuntimeGraphId
+    graphHash: string
+    sequence: number
+  }
+}
+
+export type RuntimeInvocationResult = {
+  outputs: Record<string, unknown>
+  snapshot: RuntimeSnapshot
+  evidence: RuntimeEvidenceManifest
+}
+
+function normalizeToken(value: string, label: string): string {
+  const normalized = value.trim()
+
+  if (!normalized) {
+    throw new Error(`${label} must not be empty`)
+  }
+
+  return normalized
+}
+
+export function classifyRuntimeSourceModality(
+  mediaType?: string
+): RuntimeSourceModality {
+  const normalized = mediaType?.trim().toLowerCase()
+
+  if (!normalized) {
+    return 'binary'
+  }
+
+  if (normalized === 'application/json' || normalized.endsWith('+json')) {
+    return 'structured'
+  }
+
+  const family = normalized.split('/')[0]
+
+  if (
+    family === 'audio' ||
+    family === 'image' ||
+    family === 'text' ||
+    family === 'video'
+  ) {
+    return family
+  }
+
+  return 'binary'
+}
+
+export function normalizeRuntimeSources(
+  sources: RuntimeSource[] = []
+): RuntimeEvidenceSource[] {
+  const seen = new Set<string>()
+
+  const normalized = sources.map((source) => {
+    const id = normalizeToken(source.id, 'runtime source id')
+
+    if (seen.has(id)) {
+      throw new Error(`duplicate runtime source id: ${id}`)
+    }
+
+    seen.add(id)
+
+    const mediaType = source.mediaType?.trim().toLowerCase() || undefined
+    const locator = source.locator?.trim() || undefined
+    const digest = source.digest?.trim().toLowerCase() || undefined
+
+    return {
+      id,
+      kind: source.kind,
+      modality: source.modality ?? classifyRuntimeSourceModality(mediaType),
+      ...(mediaType ? { mediaType } : {}),
+      ...(locator ? { locator } : {}),
+      ...(digest ? { digest } : {}),
+    }
+  })
+
+  return normalized.sort((a, b) => a.id.localeCompare(b.id))
+}
+
+export async function runRuntimeInvocation(
+  runtime: GraphRuntime,
+  invocation: RuntimeInvocation
+): Promise<RuntimeInvocationResult> {
+  const requestId = normalizeToken(invocation.requestId, 'runtime request id')
+  const sources = normalizeRuntimeSources(invocation.sources)
+  const sourceIds = new Set(sources.map(({ id }) => id))
+  const inputs = (invocation.inputs ?? []).map((input) => {
+    const pinId = normalizeToken(input.pinId, 'runtime input pin id')
+    const sourceId = input.sourceId
+      ? normalizeToken(input.sourceId, 'runtime input source id')
+      : undefined
+
+    if (sourceId && !sourceIds.has(sourceId)) {
+      throw new Error(`runtime input references unknown source: ${sourceId}`)
+    }
+
+    return { ...input, pinId, sourceId }
+  })
+  const outputPins = (invocation.outputs ?? []).map(({ pinId }) =>
+    normalizeToken(pinId, 'runtime output pin id')
+  )
+
+  if (new Set(outputPins).size !== outputPins.length) {
+    throw new Error('runtime output pin ids must be unique')
+  }
+
+  const manifest = normalizeCapabilityManifest(invocation.manifest)
+  const availableCapabilities = invocation.availableCapabilities ?? []
+  assertCapabilities(manifest, availableCapabilities)
+
+  const graphHash = await hashGraphSpec(invocation.spec)
+  await runtime.validate(invocation.spec)
+  const graphId = await runtime.instantiate(invocation.spec, {
+    capabilities: availableCapabilities,
+    manifest,
+  })
+
+  await runtime.start(graphId)
+
+  for (const input of inputs) {
+    await runtime.push(graphId, input.pinId, input.data)
+  }
+
+  const outputs: Record<string, unknown> = {}
+  for (const pinId of outputPins) {
+    outputs[pinId] = await runtime.take(graphId, pinId)
+  }
+
+  const snapshot = await runtime.snapshot(graphId)
+  await runtime.stop(graphId)
+
+  if (snapshot.graphHash !== graphHash) {
+    throw new Error(
+      `runtime snapshot hash mismatch: expected ${graphHash}, received ${snapshot.graphHash}`
+    )
+  }
+
+  return {
+    outputs,
+    snapshot,
+    evidence: {
+      version: 'unit.runtime-evidence/1',
+      requestId,
+      graphId,
+      graphHash,
+      sources,
+      outputPins,
+      snapshot: {
+        graphId: snapshot.graphId,
+        graphHash: snapshot.graphHash,
+        sequence: snapshot.sequence,
+      },
+    },
+  }
+}

--- a/src/test/runtime/index.ts
+++ b/src/test/runtime/index.ts
@@ -1,2 +1,3 @@
 import './capability'
 import './conformance'
+import './interoperability'

--- a/src/test/runtime/interoperability.ts
+++ b/src/test/runtime/interoperability.ts
@@ -1,0 +1,139 @@
+import * as assert from 'assert'
+import { hashGraphSpec } from '../../spec/identity'
+import {
+  classifyRuntimeSourceModality,
+  normalizeRuntimeSources,
+  runRuntimeInvocation,
+  RuntimeInvocation,
+} from '../../runtime/interoperability'
+import {
+  GraphRuntime,
+  InstantiateGraphOptions,
+  RuntimeEvent,
+  RuntimeSnapshot,
+} from '../../runtime/contract'
+import { GraphSpec } from '../../types/GraphSpec'
+
+assert.equal(classifyRuntimeSourceModality('image/png'), 'image')
+assert.equal(classifyRuntimeSourceModality('application/ld+json'), 'structured')
+assert.equal(classifyRuntimeSourceModality(undefined), 'binary')
+
+assert.deepEqual(
+  normalizeRuntimeSources([
+    {
+      id: 'source-b',
+      kind: 'uri',
+      mediaType: ' IMAGE/PNG ',
+      locator: ' https://example.invalid/b.png ',
+    },
+    {
+      id: 'source-a',
+      kind: 'inline',
+      mediaType: 'application/json',
+      digest: ' ABC123 ',
+    },
+  ]),
+  [
+    {
+      id: 'source-a',
+      kind: 'inline',
+      modality: 'structured',
+      mediaType: 'application/json',
+      digest: 'abc123',
+    },
+    {
+      id: 'source-b',
+      kind: 'uri',
+      modality: 'image',
+      mediaType: 'image/png',
+      locator: 'https://example.invalid/b.png',
+    },
+  ]
+)
+
+assert.throws(
+  () =>
+    normalizeRuntimeSources([
+      { id: 'duplicate', kind: 'inline' },
+      { id: 'duplicate', kind: 'inline' },
+    ]),
+  /duplicate runtime source id/
+)
+
+class MemoryRuntime implements GraphRuntime {
+  private data = new Map<string, Record<string, unknown>>()
+  private hashes = new Map<string, string>()
+
+  validate(_spec: GraphSpec): void {}
+
+  async instantiate(
+    spec: GraphSpec,
+    _options?: InstantiateGraphOptions
+  ): Promise<string> {
+    const graphId = `graph-${this.data.size}`
+    this.data.set(graphId, {})
+    this.hashes.set(graphId, await hashGraphSpec(spec))
+    return graphId
+  }
+
+  start(_graphId: string): void {}
+
+  push(graphId: string, pinId: string, data: unknown): void {
+    this.data.get(graphId)![pinId] = data
+  }
+
+  take(graphId: string, pinId: string): unknown {
+    return this.data.get(graphId)![pinId]
+  }
+
+  snapshot(graphId: string): RuntimeSnapshot {
+    return {
+      graphId,
+      graphHash: this.hashes.get(graphId)!,
+      sequence: 7,
+      state: { ...this.data.get(graphId) },
+    }
+  }
+
+  restore(snapshot: RuntimeSnapshot): string {
+    this.data.set(snapshot.graphId, snapshot.state as Record<string, unknown>)
+    this.hashes.set(snapshot.graphId, snapshot.graphHash)
+    return snapshot.graphId
+  }
+
+  stop(_graphId: string): void {}
+
+  async *events(_graphId: string): AsyncIterable<RuntimeEvent> {}
+}
+
+const invocation: RuntimeInvocation = {
+  requestId: ' expression-route-1 ',
+  spec: { id: 'interop-fixture', name: 'interoperability fixture' },
+  manifest: { required: ['network.http'] },
+  availableCapabilities: ['network.http'],
+  sources: [
+    {
+      id: 'source-1',
+      kind: 'inline',
+      mediaType: 'text/plain',
+      digest: 'ABCDEF',
+    },
+  ],
+  inputs: [{ pinId: 'value', sourceId: 'source-1', data: 42 }],
+  outputs: [{ pinId: 'value' }],
+}
+
+void runRuntimeInvocation(new MemoryRuntime(), invocation)
+  .then((result) => {
+    assert.deepEqual(result.outputs, { value: 42 })
+    assert.equal(result.evidence.requestId, 'expression-route-1')
+    assert.equal(result.evidence.sources[0].modality, 'text')
+    assert.equal(result.evidence.sources[0].digest, 'abcdef')
+    assert.equal(result.evidence.snapshot.sequence, 7)
+    assert.equal(result.evidence.graphHash, result.snapshot.graphHash)
+  })
+  .catch((error) => {
+    setImmediate(() => {
+      throw error
+    })
+  })


### PR DESCRIPTION
## Summary

Adds a portable Unit-side interoperability seam for downstream control surfaces without importing IAM/product policy into the kernel.

### Runtime
- normalized external source descriptors with generic source kinds and multimodal classification
- capability-bounded `RuntimeInvocation` wrapper over `GraphRuntime`
- source-to-pin provenance validation
- generic `RuntimeEvidenceManifest` bound to canonical graph hash and snapshot sequence
- runtime exports

### Tests
- modality classification
- deterministic source normalization
- duplicate source rejection
- runtime invocation/output capture
- evidence binding to source metadata and snapshot identity

### Architecture boundary
- documents the interoperability contract
- explicitly keeps specialist routing presets, authority ceilings, publication boundaries, approvals/releases, workers/queues/schedules, and product receipts downstream
- preserves the one-way dependency: product policy -> adapter -> Unit runtime

## Validation

The new TypeScript module was syntax-checked against a minimal local reconstruction. Full repository integration validation is delegated to the existing PR workflows (`test` and `Workstation Validation`), which run build, generated-registry parity, lint, typecheck, runtime tests, and strict workstation validation.