### PR TITLE
fix(runtime): harden interoperability evidence lifecycle

### DIFF
--- a/docs/architecture/interoperability-contract.md
+++ b/docs/architecture/interoperability-contract.md
@@ -76,6 +76,20 @@ External resources should map to existing portable capabilities such as
 `extension.*` capability when a host-specific operation has no canonical Unit
 capability.
 
+The evidence manifest records the normalized required and optional capability manifest
+along with the evaluated grant and denial sets. This makes the execution boundary
+reconstructable without importing the host's policy rationale into Unit.
+
+## Lifecycle cleanup
+
+Once graph instantiation succeeds, `runRuntimeInvocation` attempts `stop(graphId)` exactly
+once before returning or propagating an execution failure. This applies when `start`,
+`push`, `take`, snapshot creation, or snapshot identity verification fails.
+
+If execution succeeds but cleanup fails, the cleanup error is propagated. If execution
+has already failed and cleanup also fails, the original execution failure remains the
+primary error.
+
 ## Evidence manifest
 
 `RuntimeEvidenceManifest` records generic execution evidence only:
@@ -84,11 +98,17 @@ capability.
 - request ID;
 - graph ID and canonical graph hash;
 - normalized source descriptors and caller-supplied digests;
+- ordered input-pin bindings, including source IDs when supplied, without input payloads;
 - requested output pin IDs;
+- normalized required and optional capabilities plus the evaluated grant and denial sets;
 - snapshot graph ID, graph hash, and execution sequence.
 
+Input payloads and output values are intentionally not duplicated into the evidence
+manifest. Downstream systems may separately persist or hash those values when their
+provenance policy requires it.
+
 The manifest deliberately excludes product receipts, organizational identities, policy
-results, approval records, and arbitrary output serialization. Downstream systems may
+rationale, approval records, and arbitrary output serialization. Downstream systems may
 bind those records to the graph hash and snapshot sequence without changing Unit's
 kernel vocabulary.
 
@@ -116,4 +136,5 @@ capabilities across Node, Web, Worker, and future hosts.
 
 Repository tests cover modality classification, deterministic source normalization,
 duplicate-source rejection, source-to-pin provenance validation, capability enforcement,
-output capture, and evidence binding to snapshot identity.
+capability evidence, output capture, snapshot identity binding, and cleanup after both
+successful and failed execution.

--- a/src/runtime/interoperability.ts
+++ b/src/runtime/interoperability.ts
@@ -65,13 +65,29 @@ export type RuntimeEvidenceSource = {
   digest?: string
 }
 
+export type RuntimeEvidenceInput = {
+  pinId: string
+  sourceId?: string
+}
+
+export type RuntimeEvidenceCapabilities = {
+  required: Capability[]
+  optional: Capability[]
+  granted: Capability[]
+  deniedRequired: Capability[]
+  deniedOptional: Capability[]
+  allowed: boolean
+}
+
 export type RuntimeEvidenceManifest = {
   version: 'unit.runtime-evidence/1'
   requestId: string
   graphId: RuntimeGraphId
   graphHash: string
   sources: RuntimeEvidenceSource[]
+  inputs: RuntimeEvidenceInput[]
   outputPins: string[]
+  capabilities: RuntimeEvidenceCapabilities
   snapshot: {
     graphId: RuntimeGraphId
     graphHash: string
@@ -172,6 +188,12 @@ export async function runRuntimeInvocation(
 
     return { ...input, pinId, sourceId }
   })
+  const evidenceInputs: RuntimeEvidenceInput[] = inputs.map(
+    ({ pinId, sourceId }) => ({
+      pinId,
+      ...(sourceId ? { sourceId } : {}),
+    })
+  )
   const outputPins = (invocation.outputs ?? []).map(({ pinId }) =>
     normalizeToken(pinId, 'runtime output pin id')
   )
@@ -182,7 +204,7 @@ export async function runRuntimeInvocation(
 
   const manifest = normalizeCapabilityManifest(invocation.manifest)
   const availableCapabilities = invocation.availableCapabilities ?? []
-  assertCapabilities(manifest, availableCapabilities)
+  const capabilityDecision = assertCapabilities(manifest, availableCapabilities)
 
   const graphHash = await hashGraphSpec(invocation.spec)
   await runtime.validate(invocation.spec)
@@ -191,41 +213,78 @@ export async function runRuntimeInvocation(
     manifest,
   })
 
-  await runtime.start(graphId)
+  let operationFailed = false
+  let operationError: unknown
+  let result: RuntimeInvocationResult | undefined
 
-  for (const input of inputs) {
-    await runtime.push(graphId, input.pinId, input.data)
-  }
+  try {
+    await runtime.start(graphId)
 
-  const outputs: Record<string, unknown> = {}
-  for (const pinId of outputPins) {
-    outputs[pinId] = await runtime.take(graphId, pinId)
-  }
+    for (const input of inputs) {
+      await runtime.push(graphId, input.pinId, input.data)
+    }
 
-  const snapshot = await runtime.snapshot(graphId)
-  await runtime.stop(graphId)
+    const outputs: Record<string, unknown> = {}
+    for (const pinId of outputPins) {
+      outputs[pinId] = await runtime.take(graphId, pinId)
+    }
 
-  if (snapshot.graphHash !== graphHash) {
-    throw new Error(
-      `runtime snapshot hash mismatch: expected ${graphHash}, received ${snapshot.graphHash}`
-    )
-  }
+    const snapshot = await runtime.snapshot(graphId)
 
-  return {
-    outputs,
-    snapshot,
-    evidence: {
-      version: 'unit.runtime-evidence/1',
-      requestId,
-      graphId,
-      graphHash,
-      sources,
-      outputPins,
-      snapshot: {
-        graphId: snapshot.graphId,
-        graphHash: snapshot.graphHash,
-        sequence: snapshot.sequence,
+    if (snapshot.graphHash !== graphHash) {
+      throw new Error(
+        `runtime snapshot hash mismatch: expected ${graphHash}, received ${snapshot.graphHash}`
+      )
+    }
+
+    result = {
+      outputs,
+      snapshot,
+      evidence: {
+        version: 'unit.runtime-evidence/1',
+        requestId,
+        graphId,
+        graphHash,
+        sources,
+        inputs: evidenceInputs,
+        outputPins,
+        capabilities: {
+          ...manifest,
+          ...capabilityDecision,
+        },
+        snapshot: {
+          graphId: snapshot.graphId,
+          graphHash: snapshot.graphHash,
+          sequence: snapshot.sequence,
+        },
       },
-    },
+    }
+  } catch (error) {
+    operationFailed = true
+    operationError = error
   }
+
+  let cleanupFailed = false
+  let cleanupError: unknown
+
+  try {
+    await runtime.stop(graphId)
+  } catch (error) {
+    cleanupFailed = true
+    cleanupError = error
+  }
+
+  if (operationFailed) {
+    throw operationError
+  }
+
+  if (cleanupFailed) {
+    throw cleanupError
+  }
+
+  if (!result) {
+    throw new Error('runtime invocation completed without a result')
+  }
+
+  return result
 }

--- a/src/test/runtime/interoperability.ts
+++ b/src/test/runtime/interoperability.ts
@@ -63,6 +63,7 @@ assert.throws(
 class MemoryRuntime implements GraphRuntime {
   private data = new Map<string, Record<string, unknown>>()
   private hashes = new Map<string, string>()
+  public stopped: string[] = []
 
   validate(_spec: GraphSpec): void {}
 
@@ -101,15 +102,26 @@ class MemoryRuntime implements GraphRuntime {
     return snapshot.graphId
   }
 
-  stop(_graphId: string): void {}
+  stop(graphId: string): void {
+    this.stopped.push(graphId)
+  }
 
   async *events(_graphId: string): AsyncIterable<RuntimeEvent> {}
+}
+
+class PushFailureRuntime extends MemoryRuntime {
+  push(_graphId: string, _pinId: string, _data: unknown): void {
+    throw new Error('push failure')
+  }
 }
 
 const invocation: RuntimeInvocation = {
   requestId: ' expression-route-1 ',
   spec: { id: 'interop-fixture', name: 'interoperability fixture' },
-  manifest: { required: ['network.http'] },
+  manifest: {
+    required: ['network.http'],
+    optional: ['media.microphone'],
+  },
   availableCapabilities: ['network.http'],
   sources: [
     {
@@ -123,15 +135,50 @@ const invocation: RuntimeInvocation = {
   outputs: [{ pinId: 'value' }],
 }
 
-void runRuntimeInvocation(new MemoryRuntime(), invocation)
+const runtime = new MemoryRuntime()
+
+void runRuntimeInvocation(runtime, invocation)
   .then((result) => {
     assert.deepEqual(result.outputs, { value: 42 })
     assert.equal(result.evidence.requestId, 'expression-route-1')
     assert.equal(result.evidence.sources[0].modality, 'text')
     assert.equal(result.evidence.sources[0].digest, 'abcdef')
+    assert.deepEqual(result.evidence.inputs, [
+      { pinId: 'value', sourceId: 'source-1' },
+    ])
+    assert.deepEqual(result.evidence.capabilities, {
+      required: ['network.http'],
+      optional: ['media.microphone'],
+      granted: ['network.http'],
+      deniedRequired: [],
+      deniedOptional: ['media.microphone'],
+      allowed: true,
+    })
     assert.equal(result.evidence.snapshot.sequence, 7)
     assert.equal(result.evidence.graphHash, result.snapshot.graphHash)
+    assert.deepEqual(runtime.stopped, ['graph-0'])
   })
+  .catch((error) => {
+    setImmediate(() => {
+      throw error
+    })
+  })
+
+const failingRuntime = new PushFailureRuntime()
+
+void runRuntimeInvocation(failingRuntime, {
+  ...invocation,
+  requestId: 'expression-route-failure',
+})
+  .then(
+    () => {
+      throw new Error('expected runtime invocation to fail')
+    },
+    (error) => {
+      assert.match(String(error), /push failure/)
+      assert.deepEqual(failingRuntime.stopped, ['graph-0'])
+    }
+  )
   .catch((error) => {
     setImmediate(() => {
       throw error


### PR DESCRIPTION
## Summary

Follow-on hardening pass after #41.

### Evidence completeness
- retain ordered input-pin bindings and source IDs without duplicating input payloads
- record normalized required/optional capabilities and the evaluated grant/denial decision
- preserve existing graph hash, source descriptors, output pins, and snapshot identity

### Lifecycle safety
- once graph instantiation succeeds, attempt `stop(graphId)` exactly once before success or error propagation
- cover failures during start/push/take/snapshot paths
- preserve the primary execution error when cleanup also fails; propagate cleanup failure when execution itself succeeded

### Tests / docs
- verify input provenance and capability evidence
- verify cleanup on successful invocation
- verify cleanup after a push failure
- document the evidence and lifecycle guarantees

This remains entirely generic Unit runtime behavior; no product routing policy or IAM-specific concepts are introduced.