### PR TITLE
feat(runtime): add capability calculus v0.1

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -3,7 +3,8 @@
 Authoritative post-consolidation architecture documents:
 
 - [Kernel Contract](kernel-contract.md) — graph identity, capabilities, lifecycle, events, snapshots, compatibility, and conformance.
-- [Runtime Interoperability Contract](interoperability-contract.md) — normalized external sources, portable invocation envelopes, capability grants, and generic execution evidence.
+- [Runtime Interoperability Contract](interoperability-contract.md) — normalized external sources, portable invocation envelopes, host-separated authority, and generic execution evidence.
+- [Capability Calculus v0.1](capability-calculus.md) — scoped capability lattice, least-authority compilation, grant binding, resource budgets, conflict/refusal rules, and security properties.
 - [Repository Boundaries](repository-boundaries.md) — admission rules and the dependency boundary between Unit and downstream products.
 - [Dependency Security Baseline](dependency-security.md) — audited dependency floor, safe remediation policy, and qualified major-migration debt.
 

--- a/docs/architecture/capability-calculus.md
+++ b/docs/architecture/capability-calculus.md
@@ -1,0 +1,317 @@
+# Capability Calculus v0.1
+
+Status: candidate generic authority calculus for the portable Unit runtime.
+
+## Purpose
+
+Unit needs to accept execution requirements from downstream systems without becoming the
+product policy engine and without allowing a serialized invocation to manufacture its own
+authority. Capability Calculus v0.1 defines the generic algebra that a trusted host policy
+engine, route negotiator, sandbox, and resource adapter can share.
+
+The governing equation is:
+
+```text
+EffectiveAuthority
+  = RequestedScope
+  ∧ HostGrant
+  ∧ AdditionalTrustedCeilings
+```
+
+Route and sandbox ceilings may be represented as additional grant layers. Every layer is
+conjunctive: a later layer may attenuate authority but may not increase it.
+
+The authority identity element is **not** supplied implicitly. When an operation requires a
+capability and there is no trusted grant layer, the effective authority is empty and the
+required capability fails closed. An operation that requires no capability authority may
+execute with an empty grant chain.
+
+## Trust split
+
+Capability class declaration and authority are host-side concerns.
+
+`RuntimeInvocation` is caller-visible and may contain only:
+
+- request and operation IDs;
+- a graph specification;
+- sources, inputs, and requested outputs;
+- optional scoped capability refinements.
+
+`RuntimeAuthorization` is a separate trusted-host input containing:
+
+- the resolved principal;
+- the authoritative required/optional capability-class manifest;
+- one or more grant/ceiling layers when authority is required;
+- optional generic conflict rules;
+- optional trusted evaluation time.
+
+The caller cannot suppress a host-required capability by omitting it from the scoped
+request. A missing scoped refinement expands to the host-declared class requirement.
+Caller fields that attempt to provide grants, available capabilities, or a replacement
+manifest are rejected by the exact invocation schema.
+
+## Runtime schema firewall
+
+All authority-bearing structures are validated at runtime rather than relying on
+TypeScript types after deserialization. The calculus rejects:
+
+- unknown object keys;
+- non-plain authority objects;
+- malformed arrays and scalar types;
+- unknown capability classes;
+- empty resource or selector allowlists;
+- non-boolean permission values;
+- negative or non-finite numeric ceilings;
+- duplicate grant IDs and duplicate conflict-rule IDs;
+- reserved map keys that could create prototype or object-method ambiguity;
+- timezone-ambiguous authorization/grant timestamps.
+
+Grant and authorization timestamps must carry an explicit `Z` or numeric UTC offset.
+
+Capability classes are either one of the canonical classes or a syntactically valid,
+non-empty lower-case `extension.*` class. An extension name passing syntax validation is
+not automatically grantable; a trusted host registry must define its semantics.
+
+## Capability lattice
+
+A `ScopedCapability` has a capability class and an optional generic scope. Scope fields are
+intentionally monotone so their meet always means "no more authority":
+
+- `resources`: a non-empty allowlist of opaque resource identifiers;
+- `selectors`: non-empty allowlists for dimensions such as method, ref, or operation;
+- `limits`: non-negative numeric **maximum** ceilings;
+- `permissions`: positive-polarity booleans where `true` permits and `false` prohibits the
+  named feature.
+
+Resource strings are opaque to Unit. A network, filesystem, repository, browser, or other
+resource adapter must canonicalize resource identity before requesting or granting a scope.
+Unit does not equate URL aliases, resolve DNS, normalize filesystem traversal, or infer Git
+object equivalence.
+
+Permission names must describe the permission itself, not a negated policy. For example,
+use `privateNetwork: false`, not `denyPrivateNetwork: true`.
+
+For two values in the same capability class, meet (`∧`) is the authorization operation:
+
+- resource allowlists intersect;
+- selector allowlists intersect per key;
+- numeric ceilings choose the smaller maximum;
+- permission booleans use logical AND;
+- incompatible resource or selector intersections eliminate the capability.
+
+Join (`∨`) is exposed for lattice analysis only. **Authorization never uses join**, because
+joining grants can amplify authority.
+
+The partial order `child <= parent` means all authority in `child` is permitted by
+`parent`. Every effective capability is checked against the original request and every
+trusted layer.
+
+## Least-authority compiler
+
+`compileLeastAuthority(request, context)` emits `unit.capability-proof/1` containing:
+
+- normalized requested capabilities;
+- effective scoped capabilities;
+- denied required and optional capabilities;
+- capability residue;
+- unique grant IDs;
+- matched conflict rules;
+- monotonicity result;
+- effective resource budget;
+- final allow/refuse decision.
+
+Capability residue records requested authority that did not survive unchanged. A required
+capability denied by any layer refuses the operation. Optional capabilities may disappear
+without refusing the operation. A matched conflict rule refuses execution even when each
+capability was individually grantable.
+
+## Grants and freshness
+
+A `unit.capability-grant/1` contains only semantics enforced in v0.1:
+
+- `grantId`;
+- `principalId`;
+- `requestId`;
+- `operationId`;
+- scoped capabilities;
+- `issuedAt`;
+- `expiresAt`;
+- optional resource budget.
+
+A grant is rejected if its principal, request, or operation differs from the trusted
+context, if its time window is invalid or inactive, or if its ID is duplicated in the
+chain.
+
+Delegation lineage, revocation, nonce use, and single-use grants are intentionally absent
+from this schema because v0.1 does not yet enforce those semantics. Security-looking fields
+must not exist merely as metadata.
+
+The grant is also not yet cryptographically bound to a graph/request-content digest. The
+trusted host must therefore ensure that `requestId` and `operationId` resolve to an
+immutable authorized request. Digest-bound grants are a candidate for a later contract
+version.
+
+## Resource budgets
+
+Budgets are authority ceilings, not advisory telemetry. The generic vocabulary includes:
+
+- wall-clock time;
+- CPU time;
+- memory bytes;
+- process count;
+- graph steps;
+- input and output bytes;
+- network bytes;
+- filesystem bytes;
+- tool calls.
+
+Across layers, each effective budget dimension is the smallest defined maximum.
+
+A proof containing a budget is executable only when the target `GraphRuntime` advertises
+`unit.resource-budgets/1`. Otherwise `runRuntimeInvocation` refuses before graph validation
+or instantiation.
+
+## Enforcement conservation
+
+A scoped proof must not be downgraded to a flat capability string. Flat capability classes
+are activation hints only.
+
+`GraphRuntime.authorityEnforcement` advertises the enforcement contracts supported by the
+runtime or its attached resource adapters:
+
+```text
+unit.scoped-capabilities/1
+unit.resource-budgets/1
+```
+
+When effective authority is scoped, `unit.scoped-capabilities/1` is required. When an
+effective budget exists, `unit.resource-budgets/1` is required. Missing support causes a
+pre-execution refusal.
+
+These markers are conformance claims, not cryptographic proofs. A runtime advertising a
+marker must actually enforce the corresponding scope/budget at the resource boundary.
+
+## Capability type system and forbidden compositions
+
+Unit does not encode IAM or organization policy. A trusted host may compile product policy
+into generic `CapabilityConflictRule` values. For example, a host can refuse a particular
+combination of network and process authority without embedding that product rule in Unit.
+
+The dependency direction is:
+
+```text
+product policy
+  -> host manifest + grants + generic conflict rules
+  -> Unit proof
+```
+
+never:
+
+```text
+product policy embedded in Unit
+```
+
+## Graph and provenance boundary
+
+The interoperability path clones and validates the graph as plain JSON-shaped data before
+hashing or execution. Canonical graph identity rejects non-JSON object classes, symbol
+keys, accessor properties, non-finite numbers, functions, symbols, and bigint values. Key
+creation during canonicalization does not use prototype setters.
+
+Source `digest` fields remain caller/adapter metadata. Unit does not dereference the source
+or recompute the digest. Downstream evidence systems must distinguish a claimed digest from
+a separately verified digest.
+
+## Attack-model qualification
+
+The v0.1 suite exercises:
+
+1. authority amplification;
+2. missing-grant default denial;
+3. scope escape and empty-scope collapse;
+4. runtime scope/budget enforcement downgrade;
+5. expired or not-yet-active grants;
+6. principal/request/operation mismatch;
+7. caller-forged authority or manifest fields;
+8. unknown-key and runtime-type confusion;
+9. duplicate grant/conflict identity;
+10. unknown capability vocabulary and malformed extension names;
+11. toxic capability combinations;
+12. resource-budget amplification;
+13. graph prototype pollution and non-JSON identity confusion.
+
+## Required properties
+
+```text
+DEFAULT_DENY_WITHOUT_GRANT
+NEVER_AMPLIFY
+NEVER_ESCAPE_SCOPE
+NEVER_COLLAPSE_EMPTY_SCOPE_TO_FLAT_AUTHORITY
+NEVER_DOWNGRADE_SCOPED_AUTHORITY
+NEVER_DOWNGRADE_RESOURCE_BUDGET
+NEVER_EXECUTE_EXPIRED
+NEVER_CROSS_PRINCIPAL
+NEVER_TREAT_CALLER_DATA_AS_GRANT
+NEVER_ACCEPT_AMBIGUOUS_GRANT_IDENTITY
+NEVER_ACCEPT_UNKNOWN_CAPABILITY_CLASS
+NEVER_ACCEPT_UNKNOWN_AUTHORITY_SCHEMA
+NEVER_BYPASS_CONFLICT_REFUSAL
+NEVER_INCREASE_RESOURCE_BUDGET
+NEVER_HASH_NON_JSON_EXECUTION_OBJECTS
+```
+
+Future contracts still need durable or adapter-specific properties:
+
+```text
+NEVER_REUSE_SINGLE_USE_GRANT
+NEVER_DELEGATE_MORE_THAN_PARENT
+NEVER_EXECUTE_REVOKED_GRANT
+NEVER_DOWNGRADE_SECURITY_IN_ROUTE_DESCENT
+NEVER_BYPASS_RESOURCE_CANONICALIZATION
+```
+
+Those require durable host state, explicit delegation-chain semantics, route-security proof
+objects, or resource-specific canonicalizers and are intentionally not faked inside the
+stateless Unit kernel.
+
+## Security conservation boundary
+
+Capability Calculus proves generic attenuation and checks declared runtime enforcement
+compatibility. It does not provide a hostile-code sandbox or prove an adapter implementation
+correct.
+
+```text
+Host Policy
+    -> Host Capability Manifest
+    -> Capability Grant/Ceilings
+    -> Least-Authority Proof
+    -> Enforcement Compatibility Check
+    -> Unit Runtime
+    -> Resource Adapter Enforcement
+    -> Effect Verification
+    -> Evidence / Receipt
+```
+
+A runtime or adapter must refuse when it cannot preserve the effective scope or budget.
+Graceful transport descent is valid only when required security invariants survive.
+
+## Non-goals of v0.1
+
+The following remain outside Unit or outside this contract version:
+
+- human/agent goal interpretation;
+- IAM roles, personas, approval policy, and organizational permissions;
+- credential brokerage;
+- durable replay/idempotency/revocation registries;
+- delegation lineage;
+- browser-profile isolation;
+- OS-level hostile-code sandboxing;
+- network SSRF/DNS policy;
+- filesystem traversal/symlink policy;
+- repository-specific GitHub semantics;
+- publication/release authority;
+- cryptographic grant-to-graph/request digest binding.
+
+Downstream systems may compile those policies into host manifests, scoped requirements,
+grants, conflict rules, budgets, and resource-adapter enforcement without changing Unit's
+generic vocabulary.

--- a/docs/architecture/interoperability-contract.md
+++ b/docs/architecture/interoperability-contract.md
@@ -5,136 +5,217 @@ Status: candidate generic adapter contract for the post-consolidation kernel lin
 ## Purpose
 
 Unit needs a stable seam between product-owned control surfaces and the portable graph
-runtime without importing product policy into the kernel. The interoperability contract
-provides that seam for normalized external sources, one-graph runtime invocations, and
-portable execution evidence.
+runtime without importing product policy into the kernel. This contract defines normalized
+external sources, one-graph invocations, host-separated authority, enforcement compatibility,
+and portable execution evidence.
 
-The TypeScript contract and helper are published in
-`src/runtime/interoperability.ts`.
+The TypeScript surface is published in `src/runtime/interoperability.ts`. Scoped authority
+semantics are defined by [Capability Calculus v0.1](capability-calculus.md).
 
-## Invocation envelope
+## Trust boundary
 
-A `RuntimeInvocation` contains only execution information that is portable across hosts:
+`RuntimeInvocation` is caller-visible. Its exact wire schema contains only:
 
-- a caller-owned `requestId`;
-- the `GraphSpec` to execute;
-- normalized source descriptors used for provenance;
-- ordered input-pin pushes, optionally linked to a source descriptor;
-- output pins to consume;
-- a capability manifest describing what the graph requires or may use;
-- the capabilities already granted by the host.
+- `requestId` and `operationId`;
+- `GraphSpec`;
+- sources;
+- ordered inputs;
+- requested outputs;
+- optional scoped capability refinements.
 
-`runRuntimeInvocation(runtime, invocation)` validates the generic envelope, evaluates
-capabilities, executes the graph through `GraphRuntime`, verifies snapshot identity, and
-returns outputs plus a `RuntimeEvidenceManifest`.
+The caller does **not** supply the authoritative capability manifest, available/granted
+capabilities, principal identity, or policy decision.
 
-The helper is intentionally a one-graph operation. Higher-order pipelines remain outside
-the kernel and may compile their work into one graph or a sequence of invocations.
+`RuntimeAuthorization` is a distinct trusted-host input containing:
 
-## Source normalization
+- the host-resolved principal ID;
+- the authoritative required/optional `CapabilityManifest`;
+- zero or more host-issued grant/ceiling layers;
+- optional generic conflict rules;
+- optional trusted evaluation time.
 
-`RuntimeSource` separates source kind from data modality.
+Unknown keys are rejected on the invocation, authorization, source, input, output, manifest,
+capability request, scope, grant, budget, and conflict-rule surfaces. This prevents a typo or
+historical authority field from being silently ignored at a security boundary.
 
-Canonical source kinds are:
+`runRuntimeInvocation(runtime, invocation, authorization)`:
 
-- `inline`
-- `file`
-- `stream`
-- `uri`
-- namespaced `extension.*` kinds
+1. validates the exact external schemas;
+2. clones the graph into plain JSON-shaped data;
+3. normalizes source and pin metadata;
+4. binds caller scope refinements to the host capability manifest;
+5. compiles least authority across trusted layers;
+6. checks runtime scope/budget enforcement compatibility;
+7. validates and instantiates the graph;
+8. executes ordered inputs/outputs;
+9. verifies snapshot graph identity;
+10. stops the graph exactly once after successful instantiation;
+11. returns outputs and `unit.runtime-evidence/2`.
 
-Canonical modalities are:
+The helper intentionally executes one graph. Higher-order pipelines remain downstream.
 
-- `text`
-- `structured`
-- `image`
-- `audio`
-- `video`
-- `binary`
-- namespaced `extension.*` modalities
+## Host-authoritative capability declaration
 
-When a modality is omitted, Unit derives it from a normalized media type. JSON and
-`+json` media types classify as `structured`; text, image, audio, and video media
-families classify directly; everything else defaults to `binary`.
+The trusted host manifest declares which capability classes the graph/adapter requires or
+may use. The caller may only refine a declared class with resource, selector, limit, or
+permission scope.
 
-Source identifiers must be non-empty and unique. Normalized sources are sorted by ID so
-the evidence surface is stable regardless of intake order. Media types and supplied
-digests are normalized to lowercase; locators are trimmed but otherwise opaque to the
-kernel.
+A scoped required capability must correspond to a host-required class. A scoped optional
+capability must correspond to a host-optional class. Undeclared scoped requests are rejected.
 
-Unit does not dereference locators or hash source bytes. The adapter that has access to
-the source is responsible for resolution and for supplying a digest when byte-level
-provenance is required.
+If the caller omits a refinement for a host-declared capability, the class requirement still
+exists as an unscoped request. Therefore under-requesting cannot suppress host-required
+authority checks.
 
-## Capability boundary
+Required authority without a trusted grant layer fails closed. Optional authority can be
+removed without failing the invocation.
 
-`availableCapabilities` represents grants already resolved by the host. It is not a
-policy declaration and Unit does not decide why a capability was granted.
+## Enforcement compatibility
 
-External resources should map to existing portable capabilities such as
-`filesystem.read`, `filesystem.write`, and `network.http`, or to a namespaced
-`extension.*` capability when a host-specific operation has no canonical Unit
-capability.
+Flat capability strings are not a valid downgrade representation for scoped authority.
+They are class-level activation hints only.
 
-The evidence manifest records the normalized required and optional capability manifest
-along with the evaluated grant and denial sets. This makes the execution boundary
-reconstructable without importing the host's policy rationale into Unit.
+`GraphRuntime.authorityEnforcement` declares which enforcement contracts the runtime or its
+resource adapters support:
+
+```text
+unit.scoped-capabilities/1
+unit.resource-budgets/1
+```
+
+A proof containing scoped effective authority requires `unit.scoped-capabilities/1`. A proof
+containing a resource budget requires `unit.resource-budgets/1`. Missing support causes a
+refusal before graph validation or instantiation.
+
+These markers are conformance assertions, not proof that an adapter is correctly
+implemented. Adapter-specific tests must verify actual scope and budget enforcement.
+
+## Graph ingress and identity
+
+Before execution, the supplied graph is canonicalized with no semantic/editor omissions to
+produce an isolated plain-data execution copy. This rejects non-JSON object classes, symbol
+keys, accessors, non-finite numbers, functions, symbols, and bigint values before they reach
+the runtime.
+
+Canonical object keys are defined as data properties rather than assigned through prototype
+setters, so a JSON key such as `__proto__` remains data and does not mutate the canonical
+object's prototype.
+
+The execution copy is hashed and supplied to `validate`/`instantiate`; the snapshot hash
+must match that execution hash.
+
+## Source normalization and provenance
+
+`RuntimeSource` separates source kind from modality.
+
+Kinds:
+
+- `inline`;
+- `file`;
+- `stream`;
+- `uri`;
+- syntactically valid `extension.*` kinds.
+
+Modalities:
+
+- `text`;
+- `structured`;
+- `image`;
+- `audio`;
+- `video`;
+- `binary`;
+- syntactically valid `extension.*` modalities.
+
+When modality is absent, media type determines common families; JSON and `+json` classify
+as `structured`, and unknown families become `binary`.
+
+Source IDs are non-empty and unique. Media types are lowercased. Locators and digests are
+trimmed but otherwise preserved as opaque metadata.
+
+Unit does not dereference locators or hash source bytes. A source digest in this contract is
+a claim unless a downstream verifier separately attests that it recomputed the digest from
+resolved bytes. Evidence systems must not equate `digest present` with `digest verified`.
+
+Resource identifiers inside capability scopes are likewise opaque to Unit. Network,
+filesystem, Git, browser, and other adapters must canonicalize resource identity before
+creating or enforcing a grant.
+
+## Grant boundary
+
+`unit.capability-grant/1` authority is bound to principal, request, operation, issuance, and
+expiry. Grant IDs must be unique within one authorization chain. Multiple trusted grant
+layers are conjunctive ceilings.
+
+V0.1 deliberately does not expose delegation lineage, revocation, nonce/max-use, or
+single-use semantics because those are not durably enforced by the stateless kernel. It
+also does not cryptographically bind a grant to a graph digest; the trusted host must keep
+request/operation identity immutable while a grant is valid.
 
 ## Lifecycle cleanup
 
-Once graph instantiation succeeds, `runRuntimeInvocation` attempts `stop(graphId)` exactly
-once before returning or propagating an execution failure. This applies when `start`,
-`push`, `take`, snapshot creation, or snapshot identity verification fails.
+After graph instantiation succeeds, `runRuntimeInvocation` attempts `stop(graphId)` exactly
+once before returning or propagating execution failure. This covers failures during start,
+push, take, snapshot creation, and snapshot identity verification.
 
-If execution succeeds but cleanup fails, the cleanup error is propagated. If execution
-has already failed and cleanup also fails, the original execution failure remains the
-primary error.
+If execution succeeds but cleanup fails, cleanup failure is propagated. If execution has
+already failed and cleanup also fails, the original execution failure remains primary.
+
+Schema, authority, and enforcement-compatibility refusals occur before instantiation and
+therefore require no runtime cleanup.
 
 ## Evidence manifest
 
-`RuntimeEvidenceManifest` records generic execution evidence only:
+`unit.runtime-evidence/2` records generic execution evidence:
 
-- contract version;
-- request ID;
-- graph ID and canonical graph hash;
-- normalized source descriptors and caller-supplied digests;
-- ordered input-pin bindings, including source IDs when supplied, without input payloads;
+- request and operation IDs;
+- trusted principal ID;
+- graph ID and graph hash;
+- normalized source descriptors;
+- ordered input-pin/source bindings without input payloads;
 - requested output pin IDs;
-- normalized required and optional capabilities plus the evaluated grant and denial sets;
-- snapshot graph ID, graph hash, and execution sequence.
+- complete `unit.capability-proof/1`;
+- grant IDs, residue, conflicts, monotonicity, and effective budget;
+- runtime scope/budget enforcement profile;
+- snapshot graph ID, graph hash, and sequence.
 
-Input payloads and output values are intentionally not duplicated into the evidence
-manifest. Downstream systems may separately persist or hash those values when their
-provenance policy requires it.
+Input payloads and output values are not duplicated into evidence. Product receipts,
+organizational policy rationale, approvals, credentials, publication state, and arbitrary
+output serialization remain downstream concerns.
 
-The manifest deliberately excludes product receipts, organizational identities, policy
-rationale, approval records, and arbitrary output serialization. Downstream systems may
-bind those records to the graph hash and snapshot sequence without changing Unit's
-kernel vocabulary.
+## Product boundary
 
-## Downstream policy boundary
+The following remain outside this contract:
 
-The following concepts are intentionally not part of this contract:
+- IAM personas/specialists and routing presets;
+- organizational role and approval policy;
+- publication boundaries;
+- workers, queues, and schedules;
+- credential brokerage;
+- durable replay, idempotency, and revocation registries;
+- browser-profile policy;
+- SSRF/DNS and filesystem-path policy;
+- repository-specific GitHub semantics;
+- higher-order stage DAGs.
 
-- specialist or persona ownership;
-- routing presets and product-specific route names;
-- authority ceilings or organizational permission policy;
-- public/private publication classification;
-- review, approval, or release gates;
-- worker, queue, or schedule semantics;
-- higher-order stage DAGs such as `depends_on`, `reads`, and `writes` policy records.
+Dependency direction remains:
 
-A downstream adapter may use all of those concepts while producing portable
-`RuntimeInvocation` values. The dependency direction remains product policy -> adapter
--> Unit runtime, never the reverse.
+```text
+product intention/policy
+  -> trusted host manifest + grants + adapter
+  -> Unit interoperability contract
+  -> runtime/resource enforcement
+```
+
+never the reverse.
 
 ## Conformance
 
-A conforming interoperability adapter should produce equivalent normalized source
-metadata and runtime evidence for the same graph, ordered inputs, outputs, and granted
-capabilities across Node, Web, Worker, and future hosts.
+A conforming adapter/runtime pair should produce equivalent normalization, least-authority
+decisions, enforcement behavior, graph identity, lifecycle behavior, and evidence for the
+same trusted inputs across Node, Web, Worker, and future hosts.
 
-Repository tests cover modality classification, deterministic source normalization,
-duplicate-source rejection, source-to-pin provenance validation, capability enforcement,
-capability evidence, output capture, snapshot identity binding, and cleanup after both
-successful and failed execution.
+Repository tests cover source normalization, exact-schema rejection, graph-ingress identity
+hardening, caller/host authority separation, default-deny behavior, scope attenuation,
+principal/request/operation/expiry binding, forged authority fields, capability-vocabulary
+validation, toxic combinations, scope/budget downgrade refusal, output capture, snapshot
+identity, and cleanup after execution failures.

--- a/docs/architecture/kernel-contract.md
+++ b/docs/architecture/kernel-contract.md
@@ -5,18 +5,18 @@ Status: candidate contract for the post-consolidation kernel line.
 ## Purpose
 
 Unit is the deterministic graph execution substrate. Product-specific orchestration,
-identity, policy, memory, prompts, and user experience belong to downstream systems
-and adapters.
+identity, policy, memory, prompts, approvals, and user experience belong to downstream
+systems and adapters.
 
 A Unit program is a graph of multi-input, multi-output state machines. Hosts provide
-platform capabilities; the kernel validates, instantiates, executes, snapshots, and
-stops graphs without requiring knowledge of the host product.
+platform capabilities and authority inputs; the kernel validates, instantiates, executes,
+snapshots, and stops graphs without requiring knowledge of the host product.
 
 ## Supported host operations
 
 The TypeScript interface is published in `src/runtime/contract.ts`.
 
-A conforming host must provide the following operations:
+A conforming host provides:
 
 1. `validate(spec)` — reject structurally invalid graph specifications.
 2. `instantiate(spec, options)` — create an isolated graph instance after capability evaluation.
@@ -28,6 +28,18 @@ A conforming host must provide the following operations:
 8. `stop(graphId)` — halt execution and release resources.
 9. `events(graphId)` — expose the ordered low-level runtime event stream.
 
+A runtime may additionally advertise authority-enforcement conformance through
+`authorityEnforcement`:
+
+```text
+unit.scoped-capabilities/1
+unit.resource-budgets/1
+```
+
+Advertising a marker means the runtime or attached resource adapters enforce that
+contract. The interoperability helper refuses a scoped/budgeted invocation when the
+required marker is missing.
+
 ## Graph identity
 
 `src/spec/identity.ts` defines canonical graph serialization and SHA-256 identity.
@@ -37,30 +49,47 @@ Canonicalization:
 - sorts object keys recursively;
 - preserves array order;
 - normalizes negative zero to zero;
-- rejects non-finite numbers and non-JSON runtime values;
+- accepts only plain JSON-shaped objects and arrays;
+- rejects non-finite numbers, functions, symbols, bigint values, class instances,
+  accessors, and symbol keys;
+- creates canonical object keys as data properties so names such as `__proto__` do not
+  mutate the canonical object's prototype;
 - removes root-level generated `system` state by default;
 - removes known nonsemantic editor metadata such as viewport, selection, layout,
   position, and generated timestamps by default.
 
-Callers may override the omitted root and metadata keys. A graph hash is the lowercase
-hex SHA-256 digest of its canonical UTF-8 JSON representation.
+Callers may override omitted root and metadata keys. The hardened interoperability path
+uses no omission lists for the execution copy, so all supplied graph fields participate in
+that execution hash.
 
-Graph hashes identify executable structure. Runtime snapshots additionally carry the
-execution sequence and mutable state.
+A graph hash is the lowercase hexadecimal SHA-256 digest of canonical UTF-8 JSON. Runtime
+snapshots additionally carry execution sequence and mutable state.
 
 ## Capability model
 
-Capability types and manifests are defined in `src/types/Capability.ts`; generic
-evaluation is implemented in `src/runtime/capability.ts`.
+Capability types are defined in `src/types/Capability.ts`.
 
-A graph or adapter may declare required and optional capabilities. Required capability
-denial prevents instantiation. Optional denial is reported but does not prevent
-execution.
+Two related surfaces exist:
 
-The kernel evaluates grants. It does not decide organizational policy. The host is
-responsible for deciding which capabilities are available to a graph.
+1. `src/runtime/capability.ts` provides class-level manifest normalization/evaluation for
+   generic and legacy runtime use.
+2. `src/runtime/capability-calculus.ts` provides scoped least-authority evaluation for the
+   hardened interoperability path.
 
-Initial canonical capability names include:
+Both surfaces runtime-validate capability vocabulary rather than relying only on TypeScript
+unions.
+
+In `runRuntimeInvocation`, the capability-class manifest is supplied by the trusted host in
+`RuntimeAuthorization`, not by the caller-visible `RuntimeInvocation`. The caller may only
+refine a host-declared capability with scope. Required host declarations cannot be removed
+through caller omission.
+
+The kernel evaluates generic authority contracts. It does not decide organizational policy.
+The host is responsible for deriving principal identity, required/optional capability
+classes, grants, ceilings, conflict rules, resource-specific canonicalization, and approval
+policy.
+
+Canonical capability classes include:
 
 - `dom.render`
 - `filesystem.read`
@@ -71,7 +100,24 @@ Initial canonical capability names include:
 - `network.tcp`
 - `process.spawn`
 - `storage.local`
-- namespaced `extension.*` capabilities
+- syntactically valid namespaced `extension.*` capabilities
+
+See [Capability Calculus v0.1](capability-calculus.md) for scoped meet/partial-order
+semantics, host-bound grants, default denial, resource budgets, and generic conflict rules.
+
+## Authority boundary
+
+A caller-visible invocation cannot carry host-granted authority. Effective authority is the
+intersection of requested scope and all trusted grant/ceiling layers. Required authority
+without a trusted grant fails closed.
+
+Flat capability classes must not be used to erase surviving scope. A scoped or budgeted
+proof is executable only on a runtime advertising the corresponding enforcement contract.
+Resource-specific enforcement remains the responsibility of the relevant adapter/runtime.
+
+Unit does not provide organization policy, credential brokerage, durable replay/revocation,
+SSRF/DNS policy, filesystem path policy, browser-profile isolation, or an OS hostile-code
+sandbox.
 
 ## Event ordering
 
@@ -91,18 +137,18 @@ The initial event vocabulary is:
 - `snapshot.created`
 - `graph.stopped`
 
-Product adapters may translate these events into higher-order task, worker, receipt,
-or telemetry records without modifying the kernel vocabulary.
+Product adapters may translate these events into higher-order tasks, workers, receipts, or
+telemetry without modifying kernel vocabulary.
 
 ## Determinism boundary
 
-The kernel guarantees deterministic canonical identity and deterministic behavior only
-for graphs whose units are deterministic under the same ordered inputs and granted
+The kernel guarantees deterministic canonical identity and deterministic behavior only for
+graphs whose units are deterministic under the same ordered inputs and effective
 capabilities.
 
-Time, randomness, network access, filesystems, media devices, and external processes
-must be represented as explicit capabilities or injected host services. Their outputs
-must be recorded by the host when replayability or proof is required.
+Time, randomness, network access, filesystems, media devices, and external processes must
+be explicit capabilities or injected host services. Their external outputs must be
+recorded by the host when replayability or effect proof is required.
 
 ## Compatibility
 
@@ -112,11 +158,13 @@ Breaking changes include:
 - changing canonical identity defaults;
 - changing snapshot interpretation;
 - renaming existing capability identifiers;
+- changing authority proof/enforcement semantics for an existing contract version;
 - changing event ordering guarantees;
 - removing a public runtime operation.
 
 New optional capabilities, event fields, and runtime operations may be added compatibly
-when existing behavior remains unchanged.
+when existing behavior remains unchanged. New authority semantics that cannot preserve the
+existing contract should use a new contract version rather than silently changing meaning.
 
 ## Conformance
 
@@ -127,7 +175,9 @@ A runtime adapter is conformant when the same fixture produces equivalent:
 - ordered pin outputs;
 - lifecycle transitions;
 - snapshot/restore behavior;
-- required-capability denial behavior.
+- required-capability denial behavior;
+- scoped capability enforcement when advertised;
+- resource-budget enforcement when advertised.
 
 Cross-platform conformance fixtures should be executed against Node, Web, Worker, and
 future host adapters as those adapters expose the contract.

--- a/docs/architecture/repository-boundaries.md
+++ b/docs/architecture/repository-boundaries.md
@@ -10,9 +10,14 @@
 - generally useful logical compositions;
 - platform adapters for Web, Node, Worker, and extensions;
 - the visual graph editor and its reusable interaction foundations;
-- capability enforcement at the runtime boundary;
+- generic capability classes, scoped attenuation, proof, and enforcement contracts;
 - low-level execution events, snapshots, and graph identity;
-- normalized source descriptors, portable runtime invocation envelopes, and generic execution evidence that do not encode product policy.
+- normalized source descriptors, portable invocation envelopes, host-authorization inputs,
+  and generic execution evidence that do not encode product policy.
+
+Unit may enforce a generic authority contract that a trusted host has already derived. It
+does not determine why a person, worker, product, or organization should possess that
+authority.
 
 ## Downstream responsibility
 
@@ -27,27 +32,39 @@ For FlowGPT OS and IAM, those concerns belong in `/new` or its descendants:
 - proof bundles and product-level receipts;
 - dashboards, mission control, branding, and application navigation;
 - product-specific AI providers and business logic;
-- specialist routing presets, authority ceilings, publication boundaries, and approval or release gates.
+- specialist routing presets, authority ceilings, publication boundaries, and approval or
+  release gates;
+- credential brokerage and durable replay/revocation policy;
+- resource-specific policy such as SSRF, filesystem traversal, browser profiles, and
+  repository-specific write controls.
 
-Downstream systems may translate their contracts into Unit graphs, normalized runtime
-invocations, and capabilities. Unit must not import those product concepts into the
-kernel.
+Downstream systems may compile these policies into generic Unit host manifests, scoped
+capability requirements, grant/ceiling layers, conflict rules, budgets, and resource
+adapter enforcement. Unit must not import the product concepts that produced those generic
+contracts.
 
 ## Integration direction
 
 The dependency direction is one-way:
 
 ```text
-product intention and policy
+product intention + organizational policy
           |
           v
-product-owned Unit adapter
+trusted product-owned adapter / authority compiler
           |
-          v
-normalized sources + typed graph + capability grant
+          +--> caller-visible RuntimeInvocation
           |
+          +--> trusted RuntimeAuthorization
+          |      - principal
+          |      - capability manifest
+          |      - grants / ceilings
+          |      - conflict rules / budgets
           v
 Unit kernel
+          |
+          v
+resource/runtime enforcement
           |
           v
 ordered outputs + events + snapshot + generic evidence
@@ -57,14 +74,17 @@ A downstream adapter may:
 
 - normalize multimodal or external sources before runtime entry;
 - compile product steps into Unit graph bundles;
-- request capabilities from product policy;
+- determine the authoritative capability-class manifest;
+- request and mint generic grants under product policy;
+- canonicalize resource identifiers before scoping them;
 - instantiate and control graphs through `GraphRuntime` or `runRuntimeInvocation`;
+- enforce resource-specific constraints represented by the generic proof;
 - convert runtime events and generic evidence into product telemetry or receipts;
 - store graph hashes and snapshots in product provenance systems.
 
-The Unit kernel may not call back into a product policy engine or assume a specific
-worker, identity, memory, routing preset, authority ceiling, publication boundary, or
-receipt schema.
+The Unit kernel may not call back into a product policy engine or assume a specific worker,
+identity, memory, routing preset, organizational authority ceiling, publication boundary,
+or receipt schema.
 
 ## Admission rule
 
@@ -72,9 +92,11 @@ A proposed change belongs in `/unit` only when all of the following are true:
 
 1. It is useful outside a single product.
 2. It can be expressed without product identity or organizational policy.
-3. Its runtime behavior is testable through generic graph fixtures.
-4. It preserves platform portability or declares a clear adapter capability.
-5. It passes generated-registry parity, typecheck, runtime tests, and strict structural validation.
+3. Its runtime behavior is testable through generic graph/authority fixtures.
+4. It preserves platform portability or declares a clear adapter enforcement capability.
+5. It fails closed when a required authority invariant cannot be represented or enforced.
+6. It passes generated-registry parity, typecheck, runtime tests, and strict structural
+   validation.
 
 Otherwise, implement it in a downstream adapter, extension pack, experiment, or product
 repository.

--- a/src/runtime/capability-calculus.ts
+++ b/src/runtime/capability-calculus.ts
@@ -1,0 +1,984 @@
+import {
+  Capability,
+  CapabilityAuthorizationContext,
+  CapabilityConflictRule,
+  CapabilityGrant,
+  CapabilityProof,
+  CapabilityRequest,
+  CapabilityScope,
+  ResourceBudget,
+  ScopedCapability,
+} from '../types/Capability'
+
+const CANONICAL_CAPABILITIES = new Set<string>([
+  'dom.render',
+  'filesystem.read',
+  'filesystem.write',
+  'media.camera',
+  'media.microphone',
+  'network.http',
+  'network.tcp',
+  'process.spawn',
+  'storage.local',
+])
+
+const EXTENSION_CAPABILITY = /^extension\.[a-z0-9][a-z0-9._-]*$/
+
+const RESERVED_MAP_KEYS = new Set([
+  '__proto__',
+  'prototype',
+  'constructor',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+  'toString',
+  'valueOf',
+  '__defineGetter__',
+  '__defineSetter__',
+  '__lookupGetter__',
+  '__lookupSetter__',
+])
+
+const EXPLICIT_TIMESTAMP =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
+
+function assertPlainRecord(
+  value: unknown,
+  label: string
+): asserts value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be a plain object`)
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${label} must be a plain object`)
+  }
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string
+): void {
+  const allowedKeys = new Set(allowed)
+
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error(`${label} contains unknown key: ${key}`)
+    }
+  }
+}
+
+function normalizeToken(value: string, label: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be a string`)
+  }
+
+  const normalized = value.trim()
+
+  if (!normalized) {
+    throw new Error(`${label} must not be empty`)
+  }
+
+  return normalized
+}
+
+function normalizeMapKey(value: string, label: string): string {
+  const normalized = normalizeToken(value, label)
+
+  if (RESERVED_MAP_KEYS.has(normalized)) {
+    throw new Error(`${label} is reserved: ${normalized}`)
+  }
+
+  return normalized
+}
+
+export function normalizeCapabilityClass(value: Capability): Capability {
+  const normalized = normalizeToken(value, 'capability class')
+
+  if (CANONICAL_CAPABILITIES.has(normalized)) {
+    return normalized as Capability
+  }
+
+  if (EXTENSION_CAPABILITY.test(normalized)) {
+    return normalized as Capability
+  }
+
+  throw new Error(`unsupported capability class: ${normalized}`)
+}
+
+function uniqueSorted(values: string[], label: string): string[] {
+  if (!Array.isArray(values)) {
+    throw new Error(`${label} must be an array`)
+  }
+
+  const normalized = values.map((value, index) => {
+    if (typeof value !== 'string') {
+      throw new Error(`${label}[${index}] must be a string`)
+    }
+    return value.trim()
+  })
+
+  return Array.from(new Set(normalized.filter(Boolean))).sort()
+}
+
+function normalizeStringMap(
+  values?: Record<string, string[]>
+): Record<string, string[]> | undefined {
+  if (values === undefined) {
+    return undefined
+  }
+
+  assertPlainRecord(values, 'capability selectors')
+  const normalized: Record<string, string[]> = {}
+
+  for (const key of Object.keys(values).sort()) {
+    const normalizedKey = normalizeMapKey(key, 'capability selector key')
+    const allowed = uniqueSorted(
+      values[key] as string[],
+      `capability selector ${normalizedKey}`
+    )
+
+    if (!allowed.length) {
+      throw new Error(`capability selector must allow at least one value: ${normalizedKey}`)
+    }
+
+    normalized[normalizedKey] = allowed
+  }
+
+  return Object.keys(normalized).length ? normalized : undefined
+}
+
+function normalizeNumberMap(
+  values?: Record<string, number>
+): Record<string, number> | undefined {
+  if (values === undefined) {
+    return undefined
+  }
+
+  assertPlainRecord(values, 'capability limits')
+  const normalized: Record<string, number> = {}
+
+  for (const key of Object.keys(values).sort()) {
+    const normalizedKey = normalizeMapKey(key, 'capability limit key')
+    const value = values[key] as number
+
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+      throw new Error(`capability limit must be a non-negative finite number: ${key}`)
+    }
+
+    normalized[normalizedKey] = value
+  }
+
+  return Object.keys(normalized).length ? normalized : undefined
+}
+
+function normalizeBooleanMap(
+  values?: Record<string, boolean>
+): Record<string, boolean> | undefined {
+  if (values === undefined) {
+    return undefined
+  }
+
+  assertPlainRecord(values, 'capability permissions')
+  const normalized: Record<string, boolean> = {}
+
+  for (const key of Object.keys(values).sort()) {
+    const normalizedKey = normalizeMapKey(key, 'capability permission key')
+    const value = values[key] as boolean
+
+    if (typeof value !== 'boolean') {
+      throw new Error(`capability permission must be boolean: ${normalizedKey}`)
+    }
+
+    normalized[normalizedKey] = value
+  }
+
+  return Object.keys(normalized).length ? normalized : undefined
+}
+
+export function normalizeCapabilityScope(
+  scope?: CapabilityScope
+): CapabilityScope | undefined {
+  if (scope === undefined) {
+    return undefined
+  }
+
+  assertPlainRecord(scope, 'capability scope')
+  assertExactKeys(
+    scope,
+    ['resources', 'selectors', 'limits', 'permissions'],
+    'capability scope'
+  )
+
+  const resources =
+    scope.resources === undefined
+      ? undefined
+      : uniqueSorted(scope.resources, 'capability resources')
+
+  if (resources !== undefined && !resources.length) {
+    throw new Error('capability resources must contain at least one resource')
+  }
+
+  const selectors = normalizeStringMap(scope.selectors)
+  const limits = normalizeNumberMap(scope.limits)
+  const permissions = normalizeBooleanMap(scope.permissions)
+
+  if (
+    resources === undefined &&
+    selectors === undefined &&
+    limits === undefined &&
+    permissions === undefined
+  ) {
+    return undefined
+  }
+
+  return {
+    ...(resources !== undefined ? { resources } : {}),
+    ...(selectors ? { selectors } : {}),
+    ...(limits ? { limits } : {}),
+    ...(permissions ? { permissions } : {}),
+  }
+}
+
+export function normalizeScopedCapability(
+  value: ScopedCapability
+): ScopedCapability {
+  assertPlainRecord(value, 'scoped capability')
+  assertExactKeys(value, ['capability', 'scope'], 'scoped capability')
+
+  const capability = normalizeCapabilityClass(value.capability)
+  const scope = normalizeCapabilityScope(value.scope)
+
+  return {
+    capability,
+    ...(scope ? { scope } : {}),
+  }
+}
+
+function normalizeCapabilityList(
+  values: ScopedCapability[],
+  label: string
+): ScopedCapability[] {
+  if (!Array.isArray(values)) {
+    throw new Error(`${label} must be an array`)
+  }
+
+  const seen = new Set<Capability>()
+  const normalized = values.map(normalizeScopedCapability)
+
+  for (const value of normalized) {
+    if (seen.has(value.capability)) {
+      throw new Error(`${label} contains duplicate capability: ${value.capability}`)
+    }
+    seen.add(value.capability)
+  }
+
+  return normalized.sort((a, b) => a.capability.localeCompare(b.capability))
+}
+
+export function normalizeCapabilityRequest(
+  request: CapabilityRequest = {}
+): Required<CapabilityRequest> {
+  assertPlainRecord(request, 'capability request')
+  assertExactKeys(request, ['required', 'optional'], 'capability request')
+
+  const required = normalizeCapabilityList(request.required ?? [], 'required capabilities')
+  const requiredClasses = new Set(required.map(({ capability }) => capability))
+  const optional = normalizeCapabilityList(request.optional ?? [], 'optional capabilities')
+
+  for (const value of optional) {
+    if (requiredClasses.has(value.capability)) {
+      throw new Error(
+        `capability cannot be both required and optional: ${value.capability}`
+      )
+    }
+  }
+
+  return { required, optional }
+}
+
+function intersectStrings(a?: string[], b?: string[]): string[] | undefined | null {
+  if (a === undefined) {
+    return b === undefined ? undefined : [...b]
+  }
+  if (b === undefined) {
+    return [...a]
+  }
+
+  const bSet = new Set(b)
+  const intersection = a.filter((value) => bSet.has(value))
+
+  return intersection.length ? uniqueSorted(intersection, 'capability intersection') : null
+}
+
+function unionStrings(a?: string[], b?: string[]): string[] | undefined {
+  if (a === undefined || b === undefined) {
+    return undefined
+  }
+
+  return uniqueSorted([...a, ...b], 'capability union')
+}
+
+function meetSelectors(
+  a?: Record<string, string[]>,
+  b?: Record<string, string[]>
+): Record<string, string[]> | undefined | null {
+  if (!a && !b) {
+    return undefined
+  }
+
+  const result: Record<string, string[]> = {}
+  const keys = uniqueSorted(
+    [...Object.keys(a ?? {}), ...Object.keys(b ?? {})],
+    'capability selector keys'
+  )
+
+  for (const key of keys) {
+    const intersection = intersectStrings(a?.[key], b?.[key])
+    if (intersection === null) {
+      return null
+    }
+    if (intersection !== undefined) {
+      result[key] = intersection
+    }
+  }
+
+  return Object.keys(result).length ? result : undefined
+}
+
+function joinSelectors(
+  a?: Record<string, string[]>,
+  b?: Record<string, string[]>
+): Record<string, string[]> | undefined {
+  if (!a || !b) {
+    return undefined
+  }
+
+  const result: Record<string, string[]> = {}
+  const keys = uniqueSorted(
+    [...Object.keys(a), ...Object.keys(b)],
+    'capability selector keys'
+  )
+
+  for (const key of keys) {
+    if (a[key] === undefined || b[key] === undefined) {
+      continue
+    }
+    result[key] = uniqueSorted(
+      [...a[key], ...b[key]],
+      `capability selector ${key}`
+    )
+  }
+
+  return Object.keys(result).length ? result : undefined
+}
+
+function meetLimits(
+  a?: Record<string, number>,
+  b?: Record<string, number>
+): Record<string, number> | undefined {
+  if (!a && !b) {
+    return undefined
+  }
+
+  const result: Record<string, number> = {}
+  const keys = uniqueSorted(
+    [...Object.keys(a ?? {}), ...Object.keys(b ?? {})],
+    'capability limit keys'
+  )
+
+  for (const key of keys) {
+    const av = a?.[key]
+    const bv = b?.[key]
+    result[key] = av === undefined ? bv! : bv === undefined ? av : Math.min(av, bv)
+  }
+
+  return result
+}
+
+function joinLimits(
+  a?: Record<string, number>,
+  b?: Record<string, number>
+): Record<string, number> | undefined {
+  if (!a || !b) {
+    return undefined
+  }
+
+  const result: Record<string, number> = {}
+
+  for (const key of uniqueSorted(
+    [...Object.keys(a), ...Object.keys(b)],
+    'capability limit keys'
+  )) {
+    if (a[key] === undefined || b[key] === undefined) {
+      continue
+    }
+    result[key] = Math.max(a[key], b[key])
+  }
+
+  return Object.keys(result).length ? result : undefined
+}
+
+function meetPermissions(
+  a?: Record<string, boolean>,
+  b?: Record<string, boolean>
+): Record<string, boolean> | undefined {
+  if (!a && !b) {
+    return undefined
+  }
+
+  const result: Record<string, boolean> = {}
+  const keys = uniqueSorted(
+    [...Object.keys(a ?? {}), ...Object.keys(b ?? {})],
+    'capability permission keys'
+  )
+
+  for (const key of keys) {
+    const av = a?.[key]
+    const bv = b?.[key]
+    result[key] = av === undefined ? bv! : bv === undefined ? av : av && bv
+  }
+
+  return result
+}
+
+function joinPermissions(
+  a?: Record<string, boolean>,
+  b?: Record<string, boolean>
+): Record<string, boolean> | undefined {
+  if (!a || !b) {
+    return undefined
+  }
+
+  const result: Record<string, boolean> = {}
+
+  for (const key of uniqueSorted(
+    [...Object.keys(a), ...Object.keys(b)],
+    'capability permission keys'
+  )) {
+    if (a[key] === undefined || b[key] === undefined) {
+      continue
+    }
+    result[key] = a[key] || b[key]
+  }
+
+  return Object.keys(result).length ? result : undefined
+}
+
+function meetScopes(
+  a?: CapabilityScope,
+  b?: CapabilityScope
+): CapabilityScope | undefined | null {
+  if (!a && !b) {
+    return undefined
+  }
+
+  const resources = intersectStrings(a?.resources, b?.resources)
+  if (resources === null) {
+    return null
+  }
+
+  const selectors = meetSelectors(a?.selectors, b?.selectors)
+  if (selectors === null) {
+    return null
+  }
+
+  const limits = meetLimits(a?.limits, b?.limits)
+  const permissions = meetPermissions(a?.permissions, b?.permissions)
+
+  return normalizeCapabilityScope({
+    ...(resources !== undefined ? { resources } : {}),
+    ...(selectors ? { selectors } : {}),
+    ...(limits ? { limits } : {}),
+    ...(permissions ? { permissions } : {}),
+  })
+}
+
+function joinScopes(
+  a?: CapabilityScope,
+  b?: CapabilityScope
+): CapabilityScope | undefined {
+  if (!a || !b) {
+    return undefined
+  }
+
+  return normalizeCapabilityScope({
+    ...(unionStrings(a.resources, b.resources) !== undefined
+      ? { resources: unionStrings(a.resources, b.resources)! }
+      : {}),
+    ...(joinSelectors(a.selectors, b.selectors)
+      ? { selectors: joinSelectors(a.selectors, b.selectors)! }
+      : {}),
+    ...(joinLimits(a.limits, b.limits)
+      ? { limits: joinLimits(a.limits, b.limits)! }
+      : {}),
+    ...(joinPermissions(a.permissions, b.permissions)
+      ? { permissions: joinPermissions(a.permissions, b.permissions)! }
+      : {}),
+  })
+}
+
+export function meetScopedCapabilities(
+  a: ScopedCapability,
+  b: ScopedCapability
+): ScopedCapability | null {
+  const left = normalizeScopedCapability(a)
+  const right = normalizeScopedCapability(b)
+
+  if (left.capability !== right.capability) {
+    return null
+  }
+
+  const scope = meetScopes(left.scope, right.scope)
+  if (scope === null) {
+    return null
+  }
+
+  return {
+    capability: left.capability,
+    ...(scope ? { scope } : {}),
+  }
+}
+
+export function joinScopedCapabilities(
+  a: ScopedCapability,
+  b: ScopedCapability
+): ScopedCapability | null {
+  const left = normalizeScopedCapability(a)
+  const right = normalizeScopedCapability(b)
+
+  if (left.capability !== right.capability) {
+    return null
+  }
+
+  const scope = joinScopes(left.scope, right.scope)
+
+  return {
+    capability: left.capability,
+    ...(scope ? { scope } : {}),
+  }
+}
+
+function isStringSubset(child?: string[], parent?: string[]): boolean {
+  if (parent === undefined) {
+    return true
+  }
+  if (child === undefined) {
+    return false
+  }
+
+  const parentSet = new Set(parent)
+  return child.every((value) => parentSet.has(value))
+}
+
+function isScopeAtMost(child?: CapabilityScope, parent?: CapabilityScope): boolean {
+  if (!parent) {
+    return true
+  }
+  if (!child) {
+    return false
+  }
+
+  if (!isStringSubset(child.resources, parent.resources)) {
+    return false
+  }
+
+  for (const key of Object.keys(parent.selectors ?? {})) {
+    if (!isStringSubset(child.selectors?.[key], parent.selectors?.[key])) {
+      return false
+    }
+  }
+
+  for (const key of Object.keys(parent.limits ?? {})) {
+    const childLimit = child.limits?.[key]
+    if (childLimit === undefined || childLimit > parent.limits![key]) {
+      return false
+    }
+  }
+
+  for (const key of Object.keys(parent.permissions ?? {})) {
+    if (parent.permissions![key] === false && child.permissions?.[key] !== false) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function isScopedCapabilityAtMost(
+  child: ScopedCapability,
+  parent: ScopedCapability
+): boolean {
+  const normalizedChild = normalizeScopedCapability(child)
+  const normalizedParent = normalizeScopedCapability(parent)
+
+  return (
+    normalizedChild.capability === normalizedParent.capability &&
+    isScopeAtMost(normalizedChild.scope, normalizedParent.scope)
+  )
+}
+
+function normalizeBudgetValue(value: number | undefined, label: string): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative finite number`)
+  }
+  return value
+}
+
+function normalizeResourceBudget(budget?: ResourceBudget): ResourceBudget | undefined {
+  if (budget === undefined) {
+    return undefined
+  }
+
+  assertPlainRecord(budget, 'resource budget')
+  assertExactKeys(
+    budget,
+    [
+      'wallTimeMs',
+      'cpuTimeMs',
+      'memoryBytes',
+      'processCount',
+      'graphSteps',
+      'inputBytes',
+      'outputBytes',
+      'networkBytes',
+      'filesystemBytes',
+      'toolCalls',
+    ],
+    'resource budget'
+  )
+
+  const normalized: ResourceBudget = {
+    wallTimeMs: normalizeBudgetValue(budget.wallTimeMs, 'wallTimeMs'),
+    cpuTimeMs: normalizeBudgetValue(budget.cpuTimeMs, 'cpuTimeMs'),
+    memoryBytes: normalizeBudgetValue(budget.memoryBytes, 'memoryBytes'),
+    processCount: normalizeBudgetValue(budget.processCount, 'processCount'),
+    graphSteps: normalizeBudgetValue(budget.graphSteps, 'graphSteps'),
+    inputBytes: normalizeBudgetValue(budget.inputBytes, 'inputBytes'),
+    outputBytes: normalizeBudgetValue(budget.outputBytes, 'outputBytes'),
+    networkBytes: normalizeBudgetValue(budget.networkBytes, 'networkBytes'),
+    filesystemBytes: normalizeBudgetValue(
+      budget.filesystemBytes,
+      'filesystemBytes'
+    ),
+    toolCalls: normalizeBudgetValue(budget.toolCalls, 'toolCalls'),
+  }
+
+  for (const key of Object.keys(normalized) as (keyof ResourceBudget)[]) {
+    if (normalized[key] === undefined) {
+      delete normalized[key]
+    }
+  }
+
+  return Object.keys(normalized).length ? normalized : undefined
+}
+
+function minDefined(...values: (number | undefined)[]): number | undefined {
+  const defined = values.filter((value): value is number => value !== undefined)
+  return defined.length ? Math.min(...defined) : undefined
+}
+
+export function meetResourceBudgets(
+  budgets: (ResourceBudget | undefined)[]
+): ResourceBudget | undefined {
+  if (!Array.isArray(budgets)) {
+    throw new Error('resource budgets must be an array')
+  }
+
+  const normalized = budgets.map(normalizeResourceBudget).filter(Boolean) as ResourceBudget[]
+
+  if (!normalized.length) {
+    return undefined
+  }
+
+  return normalizeResourceBudget({
+    wallTimeMs: minDefined(...normalized.map(({ wallTimeMs }) => wallTimeMs)),
+    cpuTimeMs: minDefined(...normalized.map(({ cpuTimeMs }) => cpuTimeMs)),
+    memoryBytes: minDefined(...normalized.map(({ memoryBytes }) => memoryBytes)),
+    processCount: minDefined(...normalized.map(({ processCount }) => processCount)),
+    graphSteps: minDefined(...normalized.map(({ graphSteps }) => graphSteps)),
+    inputBytes: minDefined(...normalized.map(({ inputBytes }) => inputBytes)),
+    outputBytes: minDefined(...normalized.map(({ outputBytes }) => outputBytes)),
+    networkBytes: minDefined(...normalized.map(({ networkBytes }) => networkBytes)),
+    filesystemBytes: minDefined(
+      ...normalized.map(({ filesystemBytes }) => filesystemBytes)
+    ),
+    toolCalls: minDefined(...normalized.map(({ toolCalls }) => toolCalls)),
+  })
+}
+
+function parseTimestamp(value: string, label: string): number {
+  const normalized = normalizeToken(value, label)
+
+  if (!EXPLICIT_TIMESTAMP.test(normalized)) {
+    throw new Error(`${label} must include an explicit UTC or numeric timezone offset`)
+  }
+
+  const timestamp = Date.parse(normalized)
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`${label} must be a valid timestamp`)
+  }
+  return timestamp
+}
+
+function normalizeGrant(
+  grant: CapabilityGrant,
+  context: CapabilityAuthorizationContext,
+  now: number
+): CapabilityGrant {
+  assertPlainRecord(grant, 'capability grant')
+  assertExactKeys(
+    grant,
+    [
+      'version',
+      'grantId',
+      'principalId',
+      'requestId',
+      'operationId',
+      'capabilities',
+      'issuedAt',
+      'expiresAt',
+      'budget',
+    ],
+    'capability grant'
+  )
+
+  if (grant.version !== 'unit.capability-grant/1') {
+    throw new Error(`unsupported capability grant version: ${String(grant.version)}`)
+  }
+
+  const grantId = normalizeToken(grant.grantId, 'capability grant id')
+  const principalId = normalizeToken(grant.principalId, 'capability grant principal id')
+  const requestId = normalizeToken(grant.requestId, 'capability grant request id')
+  const operationId = normalizeToken(grant.operationId, 'capability grant operation id')
+
+  if (principalId !== context.principalId) {
+    throw new Error(`capability grant principal mismatch: ${grantId}`)
+  }
+  if (requestId !== context.requestId) {
+    throw new Error(`capability grant request mismatch: ${grantId}`)
+  }
+  if (operationId !== context.operationId) {
+    throw new Error(`capability grant operation mismatch: ${grantId}`)
+  }
+
+  const issuedAt = parseTimestamp(grant.issuedAt, 'capability grant issuedAt')
+  const expiresAt = parseTimestamp(grant.expiresAt, 'capability grant expiresAt')
+
+  if (expiresAt <= issuedAt) {
+    throw new Error(`capability grant expiry must follow issuance: ${grantId}`)
+  }
+  if (now < issuedAt) {
+    throw new Error(`capability grant is not active yet: ${grantId}`)
+  }
+  if (now >= expiresAt) {
+    throw new Error(`capability grant is expired: ${grantId}`)
+  }
+
+  return {
+    version: 'unit.capability-grant/1',
+    grantId,
+    principalId,
+    requestId,
+    operationId,
+    capabilities: normalizeCapabilityList(
+      grant.capabilities,
+      `capability grant ${grantId}`
+    ),
+    issuedAt: grant.issuedAt,
+    expiresAt: grant.expiresAt,
+    ...(normalizeResourceBudget(grant.budget)
+      ? { budget: normalizeResourceBudget(grant.budget)! }
+      : {}),
+  }
+}
+
+function attenuateOne(
+  requested: ScopedCapability,
+  layers: CapabilityGrant[]
+): ScopedCapability | null {
+  if (!layers.length) {
+    return null
+  }
+
+  let effective: ScopedCapability | null = normalizeScopedCapability(requested)
+
+  for (const layer of layers) {
+    const ceiling = layer.capabilities.find(
+      ({ capability }) => capability === requested.capability
+    )
+
+    if (!ceiling || !effective) {
+      return null
+    }
+
+    effective = meetScopedCapabilities(effective, ceiling)
+  }
+
+  return effective
+}
+
+function sameScopedCapability(a: ScopedCapability, b: ScopedCapability): boolean {
+  return JSON.stringify(normalizeScopedCapability(a)) === JSON.stringify(normalizeScopedCapability(b))
+}
+
+function normalizeConflictRules(
+  rules?: CapabilityConflictRule[]
+): CapabilityConflictRule[] {
+  if (rules === undefined) {
+    return []
+  }
+  if (!Array.isArray(rules)) {
+    throw new Error('capability conflict rules must be an array')
+  }
+
+  const seenIds = new Set<string>()
+
+  return rules
+    .map((rule) => {
+      assertPlainRecord(rule, 'capability conflict rule')
+      assertExactKeys(rule, ['id', 'allOf'], 'capability conflict rule')
+
+      const id = normalizeToken(rule.id, 'capability conflict rule id')
+      if (seenIds.has(id)) {
+        throw new Error(`duplicate capability conflict rule id: ${id}`)
+      }
+      seenIds.add(id)
+
+      if (!Array.isArray(rule.allOf) || !rule.allOf.length) {
+        throw new Error(`capability conflict rule must name at least one capability: ${id}`)
+      }
+
+      const allOf = Array.from(
+        new Set(rule.allOf.map(normalizeCapabilityClass))
+      ).sort()
+
+      return { id, allOf }
+    })
+    .sort((a, b) => a.id.localeCompare(b.id))
+}
+
+export function compileLeastAuthority(
+  request: CapabilityRequest,
+  context: CapabilityAuthorizationContext
+): CapabilityProof {
+  assertPlainRecord(context, 'capability authorization context')
+  assertExactKeys(
+    context,
+    ['principalId', 'requestId', 'operationId', 'layers', 'conflictRules', 'now'],
+    'capability authorization context'
+  )
+
+  const principalId = normalizeToken(context.principalId, 'authorization principal id')
+  const requestId = normalizeToken(context.requestId, 'authorization request id')
+  const operationId = normalizeToken(context.operationId, 'authorization operation id')
+  const now =
+    context.now !== undefined
+      ? parseTimestamp(context.now, 'authorization time')
+      : Date.now()
+  const normalizedRequest = normalizeCapabilityRequest(request)
+
+  if (!Array.isArray(context.layers)) {
+    throw new Error('capability authorization layers must be an array')
+  }
+
+  const normalizedContext: CapabilityAuthorizationContext = {
+    principalId,
+    requestId,
+    operationId,
+    layers: context.layers,
+    ...(context.conflictRules !== undefined
+      ? { conflictRules: context.conflictRules }
+      : {}),
+    ...(context.now !== undefined ? { now: context.now } : {}),
+  }
+  const layers = context.layers.map((grant) =>
+    normalizeGrant(grant, normalizedContext, now)
+  )
+  const seenGrantIds = new Set<string>()
+
+  for (const layer of layers) {
+    if (seenGrantIds.has(layer.grantId)) {
+      throw new Error(`duplicate capability grant id: ${layer.grantId}`)
+    }
+    seenGrantIds.add(layer.grantId)
+  }
+
+  const effective: ScopedCapability[] = []
+  const deniedRequired: ScopedCapability[] = []
+  const deniedOptional: ScopedCapability[] = []
+
+  for (const requested of normalizedRequest.required) {
+    const attenuated = attenuateOne(requested, layers)
+    if (attenuated) {
+      effective.push(attenuated)
+    } else {
+      deniedRequired.push(requested)
+    }
+  }
+
+  for (const requested of normalizedRequest.optional) {
+    const attenuated = attenuateOne(requested, layers)
+    if (attenuated) {
+      effective.push(attenuated)
+    } else {
+      deniedOptional.push(requested)
+    }
+  }
+
+  effective.sort((a, b) => a.capability.localeCompare(b.capability))
+
+  const requestedAll = [...normalizedRequest.required, ...normalizedRequest.optional]
+  const residue = requestedAll.filter((requested) => {
+    const granted = effective.find(
+      ({ capability }) => capability === requested.capability
+    )
+    return !granted || !sameScopedCapability(requested, granted)
+  })
+
+  const effectiveClasses = new Set(effective.map(({ capability }) => capability))
+  const conflicts = normalizeConflictRules(context.conflictRules)
+    .filter((rule) => rule.allOf.every((capability) => effectiveClasses.has(capability)))
+    .map(({ id }) => id)
+
+  const monotonic = effective.every((value) => {
+    const requested = requestedAll.find(
+      ({ capability }) => capability === value.capability
+    )
+
+    return (
+      requested !== undefined &&
+      isScopedCapabilityAtMost(value, requested) &&
+      layers.every((layer) => {
+        const ceiling = layer.capabilities.find(
+          ({ capability }) => capability === value.capability
+        )
+        return ceiling !== undefined && isScopedCapabilityAtMost(value, ceiling)
+      })
+    )
+  })
+  const budget = meetResourceBudgets(layers.map(({ budget: layerBudget }) => layerBudget))
+
+  return {
+    version: 'unit.capability-proof/1',
+    requestId,
+    operationId,
+    principalId,
+    grantIds: layers.map(({ grantId }) => grantId),
+    requested: normalizedRequest,
+    effective,
+    deniedRequired,
+    deniedOptional,
+    residue,
+    conflicts,
+    monotonic,
+    allowed: deniedRequired.length === 0 && conflicts.length === 0 && monotonic,
+    ...(budget ? { budget } : {}),
+  }
+}

--- a/src/runtime/capability.ts
+++ b/src/runtime/capability.ts
@@ -3,17 +3,68 @@ import {
   CapabilityDecision,
   CapabilityManifest,
 } from '../types/Capability'
+import { normalizeCapabilityClass } from './capability-calculus'
 
-function uniqueSorted(values: Iterable<Capability>): Capability[] {
-  return Array.from(new Set(values)).sort()
+function assertPlainRecord(
+  value: unknown,
+  label: string
+): asserts value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be a plain object`)
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${label} must be a plain object`)
+  }
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string
+): void {
+  const allowedKeys = new Set(allowed)
+
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error(`${label} contains unknown key: ${key}`)
+    }
+  }
+}
+
+function uniqueSorted(values: Iterable<Capability>, label: string): Capability[] {
+  let array: Capability[]
+
+  try {
+    array = Array.from(values)
+  } catch {
+    throw new Error(`${label} must be iterable`)
+  }
+
+  return Array.from(new Set(array.map(normalizeCapabilityClass))).sort()
 }
 
 export function normalizeCapabilityManifest(
   manifest: CapabilityManifest = {}
 ): Required<CapabilityManifest> {
-  const required = uniqueSorted(manifest.required ?? [])
-  const optional = uniqueSorted(
-    (manifest.optional ?? []).filter((capability) => !required.includes(capability))
+  assertPlainRecord(manifest, 'capability manifest')
+  assertExactKeys(manifest, ['required', 'optional'], 'capability manifest')
+
+  if (manifest.required !== undefined && !Array.isArray(manifest.required)) {
+    throw new Error('required capabilities must be an array')
+  }
+  if (manifest.optional !== undefined && !Array.isArray(manifest.optional)) {
+    throw new Error('optional capabilities must be an array')
+  }
+
+  const required = uniqueSorted(manifest.required ?? [], 'required capabilities')
+  const optionalCandidates = uniqueSorted(
+    manifest.optional ?? [],
+    'optional capabilities'
+  )
+  const optional = optionalCandidates.filter(
+    (capability) => !required.includes(capability)
   )
 
   return { required, optional }
@@ -24,7 +75,8 @@ export function evaluateCapabilityManifest(
   available: Iterable<Capability>
 ): CapabilityDecision {
   const normalized = normalizeCapabilityManifest(manifest)
-  const availableSet = new Set(available)
+  const availableCapabilities = uniqueSorted(available, 'available capabilities')
+  const availableSet = new Set(availableCapabilities)
   const deniedRequired = normalized.required.filter(
     (capability) => !availableSet.has(capability)
   )
@@ -36,7 +88,8 @@ export function evaluateCapabilityManifest(
     granted: uniqueSorted(
       [...normalized.required, ...normalized.optional].filter((capability) =>
         availableSet.has(capability)
-      )
+      ),
+      'granted capabilities'
     ),
     deniedRequired,
     deniedOptional,

--- a/src/runtime/contract.ts
+++ b/src/runtime/contract.ts
@@ -1,8 +1,18 @@
 import { GraphSpec } from '../types/GraphSpec'
-import { Capability, CapabilityManifest } from '../types/Capability'
+import {
+  Capability,
+  CapabilityManifest,
+  CapabilityProof,
+  ScopedCapability,
+} from '../types/Capability'
 
 export type RuntimeGraphId = string
 export type RuntimePinDirection = 'input' | 'output'
+
+export type RuntimeAuthorityEnforcement = {
+  scopedCapabilities?: 'unit.scoped-capabilities/1'
+  resourceBudgets?: 'unit.resource-budgets/1'
+}
 
 export type RuntimeEvent = {
   sequence: number
@@ -34,9 +44,12 @@ export type RuntimeSnapshot = {
 export type InstantiateGraphOptions = {
   capabilities?: Capability[]
   manifest?: CapabilityManifest
+  scopedCapabilities?: ScopedCapability[]
+  capabilityProof?: CapabilityProof
 }
 
 export interface GraphRuntime {
+  readonly authorityEnforcement?: RuntimeAuthorityEnforcement
   validate(spec: GraphSpec): Promise<void> | void
   instantiate(
     spec: GraphSpec,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,4 +1,5 @@
 export * from './capability'
+export * from './capability-calculus'
 export * from './conformance'
 export * from './contract'
 export * from './interoperability'

--- a/src/runtime/interoperability.ts
+++ b/src/runtime/interoperability.ts
@@ -1,12 +1,19 @@
-import { hashGraphSpec } from '../spec/identity'
-import { Capability, CapabilityManifest } from '../types/Capability'
-import { GraphSpec } from '../types/GraphSpec'
+import { canonicalizeGraphSpec, hashGraphSpec } from '../spec/identity'
 import {
-  assertCapabilities,
-  normalizeCapabilityManifest,
-} from './capability'
+  Capability,
+  CapabilityConflictRule,
+  CapabilityGrant,
+  CapabilityManifest,
+  CapabilityProof,
+  CapabilityRequest,
+  ScopedCapability,
+} from '../types/Capability'
+import { GraphSpec } from '../types/GraphSpec'
+import { compileLeastAuthority, normalizeCapabilityRequest } from './capability-calculus'
+import { normalizeCapabilityManifest } from './capability'
 import {
   GraphRuntime,
+  RuntimeAuthorityEnforcement,
   RuntimeGraphId,
   RuntimeSnapshot,
 } from './contract'
@@ -48,12 +55,20 @@ export type RuntimeInvocationOutput = {
 
 export type RuntimeInvocation = {
   requestId: string
+  operationId: string
   spec: GraphSpec
   sources?: RuntimeSource[]
   inputs?: RuntimeInvocationInput[]
   outputs?: RuntimeInvocationOutput[]
-  manifest?: CapabilityManifest
-  availableCapabilities?: Capability[]
+  capabilityRequest?: CapabilityRequest
+}
+
+export type RuntimeAuthorization = {
+  principalId: string
+  manifest: CapabilityManifest
+  layers: CapabilityGrant[]
+  conflictRules?: CapabilityConflictRule[]
+  now?: string
 }
 
 export type RuntimeEvidenceSource = {
@@ -70,24 +85,25 @@ export type RuntimeEvidenceInput = {
   sourceId?: string
 }
 
-export type RuntimeEvidenceCapabilities = {
-  required: Capability[]
-  optional: Capability[]
-  granted: Capability[]
-  deniedRequired: Capability[]
-  deniedOptional: Capability[]
-  allowed: boolean
+export type RuntimeEvidenceCapabilities = CapabilityProof
+
+export type RuntimeEvidenceEnforcement = {
+  scopedCapabilities: 'none' | 'unit.scoped-capabilities/1'
+  resourceBudgets: 'none' | 'unit.resource-budgets/1'
 }
 
 export type RuntimeEvidenceManifest = {
-  version: 'unit.runtime-evidence/1'
+  version: 'unit.runtime-evidence/2'
   requestId: string
+  operationId: string
+  principalId: string
   graphId: RuntimeGraphId
   graphHash: string
   sources: RuntimeEvidenceSource[]
   inputs: RuntimeEvidenceInput[]
   outputPins: string[]
   capabilities: RuntimeEvidenceCapabilities
+  enforcement: RuntimeEvidenceEnforcement
   snapshot: {
     graphId: RuntimeGraphId
     graphHash: string
@@ -101,7 +117,50 @@ export type RuntimeInvocationResult = {
   evidence: RuntimeEvidenceManifest
 }
 
+const SOURCE_KINDS = new Set(['file', 'inline', 'stream', 'uri'])
+const SOURCE_MODALITIES = new Set([
+  'audio',
+  'binary',
+  'image',
+  'structured',
+  'text',
+  'video',
+])
+const EXTENSION_TOKEN = /^extension\.[a-z0-9][a-z0-9._-]*$/
+
+function assertPlainRecord(
+  value: unknown,
+  label: string
+): asserts value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be a plain object`)
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${label} must be a plain object`)
+  }
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string
+): void {
+  const allowedKeys = new Set(allowed)
+
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error(`${label} contains unknown key: ${key}`)
+    }
+  }
+}
+
 function normalizeToken(value: string, label: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be a string`)
+  }
+
   const normalized = value.trim()
 
   if (!normalized) {
@@ -109,6 +168,49 @@ function normalizeToken(value: string, label: string): string {
   }
 
   return normalized
+}
+
+function normalizeOptionalToken(
+  value: string | undefined,
+  label: string
+): string | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  return normalizeToken(value, label)
+}
+
+function normalizeSourceKind(value: RuntimeSourceKind): RuntimeSourceKind {
+  const normalized = normalizeToken(value, 'runtime source kind')
+
+  if (SOURCE_KINDS.has(normalized) || EXTENSION_TOKEN.test(normalized)) {
+    return normalized as RuntimeSourceKind
+  }
+
+  throw new Error(`unsupported runtime source kind: ${normalized}`)
+}
+
+function normalizeSourceModality(
+  value: RuntimeSourceModality
+): RuntimeSourceModality {
+  const normalized = normalizeToken(value, 'runtime source modality')
+
+  if (SOURCE_MODALITIES.has(normalized) || EXTENSION_TOKEN.test(normalized)) {
+    return normalized as RuntimeSourceModality
+  }
+
+  throw new Error(`unsupported runtime source modality: ${normalized}`)
+}
+
+function optionalArray<T>(value: T[] | undefined, label: string): T[] {
+  if (value === undefined) {
+    return []
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`)
+  }
+  return value
 }
 
 export function classifyRuntimeSourceModality(
@@ -139,11 +241,19 @@ export function classifyRuntimeSourceModality(
 }
 
 export function normalizeRuntimeSources(
-  sources: RuntimeSource[] = []
+  sources?: RuntimeSource[]
 ): RuntimeEvidenceSource[] {
+  const values = optionalArray(sources, 'runtime sources')
   const seen = new Set<string>()
 
-  const normalized = sources.map((source) => {
+  const normalized = values.map((source) => {
+    assertPlainRecord(source, 'runtime source')
+    assertExactKeys(
+      source,
+      ['id', 'kind', 'modality', 'mediaType', 'locator', 'digest'],
+      'runtime source'
+    )
+
     const id = normalizeToken(source.id, 'runtime source id')
 
     if (seen.has(id)) {
@@ -152,14 +262,23 @@ export function normalizeRuntimeSources(
 
     seen.add(id)
 
-    const mediaType = source.mediaType?.trim().toLowerCase() || undefined
-    const locator = source.locator?.trim() || undefined
-    const digest = source.digest?.trim().toLowerCase() || undefined
+    const kind = normalizeSourceKind(source.kind)
+    const mediaTypeValue = normalizeOptionalToken(
+      source.mediaType,
+      'runtime source media type'
+    )
+    const mediaType = mediaTypeValue?.toLowerCase()
+    const locator = normalizeOptionalToken(source.locator, 'runtime source locator')
+    const digest = normalizeOptionalToken(source.digest, 'runtime source digest')
+    const modality =
+      source.modality === undefined
+        ? classifyRuntimeSourceModality(mediaType)
+        : normalizeSourceModality(source.modality)
 
     return {
       id,
-      kind: source.kind,
-      modality: source.modality ?? classifyRuntimeSourceModality(mediaType),
+      kind,
+      modality,
       ...(mediaType ? { mediaType } : {}),
       ...(locator ? { locator } : {}),
       ...(digest ? { digest } : {}),
@@ -169,18 +288,167 @@ export function normalizeRuntimeSources(
   return normalized.sort((a, b) => a.id.localeCompare(b.id))
 }
 
+function bindCapabilityRequest(
+  manifest: CapabilityManifest,
+  request: CapabilityRequest = {}
+): Required<CapabilityRequest> {
+  const normalizedManifest = normalizeCapabilityManifest(manifest)
+  const normalizedRequest = normalizeCapabilityRequest(request)
+  const requiredClasses = new Set(normalizedManifest.required)
+  const optionalClasses = new Set(normalizedManifest.optional)
+
+  for (const value of normalizedRequest.required) {
+    if (!requiredClasses.has(value.capability)) {
+      throw new Error(
+        `scoped required capability is not declared required by host: ${value.capability}`
+      )
+    }
+  }
+
+  for (const value of normalizedRequest.optional) {
+    if (!optionalClasses.has(value.capability)) {
+      throw new Error(
+        `scoped optional capability is not declared optional by host: ${value.capability}`
+      )
+    }
+  }
+
+  const findScoped = (
+    capability: Capability,
+    values: ScopedCapability[]
+  ): ScopedCapability =>
+    values.find((value) => value.capability === capability) ?? { capability }
+
+  return {
+    required: normalizedManifest.required.map((capability) =>
+      findScoped(capability, normalizedRequest.required)
+    ),
+    optional: normalizedManifest.optional.map((capability) =>
+      findScoped(capability, normalizedRequest.optional)
+    ),
+  }
+}
+
+function describeAuthorizationFailure(proof: CapabilityProof): string {
+  const reasons: string[] = []
+
+  if (proof.deniedRequired.length) {
+    reasons.push(
+      `missing required capabilities: ${proof.deniedRequired
+        .map(({ capability }) => capability)
+        .join(', ')}`
+    )
+  }
+  if (proof.conflicts.length) {
+    reasons.push(`forbidden capability combinations: ${proof.conflicts.join(', ')}`)
+  }
+  if (!proof.monotonic) {
+    reasons.push('capability attenuation proof is not monotonic')
+  }
+
+  return reasons.join('; ') || 'authorization proof rejected'
+}
+
+function requireAuthorityEnforcement(
+  runtime: GraphRuntime,
+  proof: CapabilityProof
+): RuntimeEvidenceEnforcement {
+  const support: RuntimeAuthorityEnforcement = runtime.authorityEnforcement ?? {}
+  const requiresScopedCapabilities = proof.effective.some(
+    ({ scope }) => scope !== undefined
+  )
+  const requiresResourceBudgets = proof.budget !== undefined
+
+  if (
+    requiresScopedCapabilities &&
+    support.scopedCapabilities !== 'unit.scoped-capabilities/1'
+  ) {
+    throw new Error(
+      'runtime authorization denied: scoped capability enforcement is required but unsupported'
+    )
+  }
+
+  if (
+    requiresResourceBudgets &&
+    support.resourceBudgets !== 'unit.resource-budgets/1'
+  ) {
+    throw new Error(
+      'runtime authorization denied: resource budget enforcement is required but unsupported'
+    )
+  }
+
+  return {
+    scopedCapabilities: support.scopedCapabilities ?? 'none',
+    resourceBudgets: support.resourceBudgets ?? 'none',
+  }
+}
+
 export async function runRuntimeInvocation(
   runtime: GraphRuntime,
-  invocation: RuntimeInvocation
+  invocation: RuntimeInvocation,
+  authorization: RuntimeAuthorization
 ): Promise<RuntimeInvocationResult> {
+  assertPlainRecord(invocation, 'runtime invocation')
+  assertExactKeys(
+    invocation,
+    [
+      'requestId',
+      'operationId',
+      'spec',
+      'sources',
+      'inputs',
+      'outputs',
+      'capabilityRequest',
+    ],
+    'runtime invocation'
+  )
+  assertPlainRecord(authorization, 'runtime authorization')
+  assertExactKeys(
+    authorization,
+    ['principalId', 'manifest', 'layers', 'conflictRules', 'now'],
+    'runtime authorization'
+  )
+  assertPlainRecord(authorization.manifest, 'runtime capability manifest')
+  assertExactKeys(
+    authorization.manifest,
+    ['required', 'optional'],
+    'runtime capability manifest'
+  )
+
+  if (
+    authorization.manifest.required !== undefined &&
+    !Array.isArray(authorization.manifest.required)
+  ) {
+    throw new Error('runtime required capability manifest must be an array')
+  }
+  if (
+    authorization.manifest.optional !== undefined &&
+    !Array.isArray(authorization.manifest.optional)
+  ) {
+    throw new Error('runtime optional capability manifest must be an array')
+  }
+
   const requestId = normalizeToken(invocation.requestId, 'runtime request id')
+  const operationId = normalizeToken(invocation.operationId, 'runtime operation id')
+  const principalId = normalizeToken(
+    authorization.principalId,
+    'runtime authorization principal id'
+  )
+  const spec = canonicalizeGraphSpec(invocation.spec, {
+    omitMetadataKeys: [],
+    omitRootKeys: [],
+  })
   const sources = normalizeRuntimeSources(invocation.sources)
   const sourceIds = new Set(sources.map(({ id }) => id))
-  const inputs = (invocation.inputs ?? []).map((input) => {
+  const inputs = optionalArray(invocation.inputs, 'runtime inputs').map((input) => {
+    assertPlainRecord(input, 'runtime input')
+    assertExactKeys(input, ['pinId', 'data', 'sourceId'], 'runtime input')
+
     const pinId = normalizeToken(input.pinId, 'runtime input pin id')
-    const sourceId = input.sourceId
-      ? normalizeToken(input.sourceId, 'runtime input source id')
-      : undefined
+    const sourceId = normalizeOptionalToken(
+      input.sourceId,
+      'runtime input source id'
+    )
 
     if (sourceId && !sourceIds.has(sourceId)) {
       throw new Error(`runtime input references unknown source: ${sourceId}`)
@@ -194,23 +462,50 @@ export async function runRuntimeInvocation(
       ...(sourceId ? { sourceId } : {}),
     })
   )
-  const outputPins = (invocation.outputs ?? []).map(({ pinId }) =>
-    normalizeToken(pinId, 'runtime output pin id')
+  const outputPins = optionalArray(invocation.outputs, 'runtime outputs').map(
+    (output) => {
+      assertPlainRecord(output, 'runtime output')
+      assertExactKeys(output, ['pinId'], 'runtime output')
+      return normalizeToken(output.pinId, 'runtime output pin id')
+    }
   )
 
   if (new Set(outputPins).size !== outputPins.length) {
     throw new Error('runtime output pin ids must be unique')
   }
 
-  const manifest = normalizeCapabilityManifest(invocation.manifest)
-  const availableCapabilities = invocation.availableCapabilities ?? []
-  const capabilityDecision = assertCapabilities(manifest, availableCapabilities)
-
-  const graphHash = await hashGraphSpec(invocation.spec)
-  await runtime.validate(invocation.spec)
-  const graphId = await runtime.instantiate(invocation.spec, {
-    capabilities: availableCapabilities,
+  const manifest = normalizeCapabilityManifest(authorization.manifest)
+  const capabilityRequest = bindCapabilityRequest(
     manifest,
+    invocation.capabilityRequest
+  )
+  const capabilityProof = compileLeastAuthority(capabilityRequest, {
+    principalId,
+    requestId,
+    operationId,
+    layers: authorization.layers,
+    conflictRules: authorization.conflictRules,
+    now: authorization.now,
+  })
+
+  if (!capabilityProof.allowed) {
+    throw new Error(
+      `runtime authorization denied: ${describeAuthorizationFailure(capabilityProof)}`
+    )
+  }
+
+  const enforcement = requireAuthorityEnforcement(runtime, capabilityProof)
+  const capabilities = Array.from(
+    new Set(capabilityProof.effective.map(({ capability }) => capability))
+  ).sort() as Capability[]
+
+  const graphHash = await hashGraphSpec(spec)
+  await runtime.validate(spec)
+  const graphId = await runtime.instantiate(spec, {
+    capabilities,
+    manifest,
+    scopedCapabilities: capabilityProof.effective,
+    capabilityProof,
   })
 
   let operationFailed = false
@@ -224,10 +519,11 @@ export async function runRuntimeInvocation(
       await runtime.push(graphId, input.pinId, input.data)
     }
 
-    const outputs: Record<string, unknown> = {}
+    const outputEntries: [string, unknown][] = []
     for (const pinId of outputPins) {
-      outputs[pinId] = await runtime.take(graphId, pinId)
+      outputEntries.push([pinId, await runtime.take(graphId, pinId)])
     }
+    const outputs = Object.fromEntries(outputEntries) as Record<string, unknown>
 
     const snapshot = await runtime.snapshot(graphId)
 
@@ -241,17 +537,17 @@ export async function runRuntimeInvocation(
       outputs,
       snapshot,
       evidence: {
-        version: 'unit.runtime-evidence/1',
+        version: 'unit.runtime-evidence/2',
         requestId,
+        operationId,
+        principalId,
         graphId,
         graphHash,
         sources,
         inputs: evidenceInputs,
         outputPins,
-        capabilities: {
-          ...manifest,
-          ...capabilityDecision,
-        },
+        capabilities: capabilityProof,
+        enforcement,
         snapshot: {
           graphId: snapshot.graphId,
           graphHash: snapshot.graphHash,

--- a/src/spec/identity.ts
+++ b/src/spec/identity.ts
@@ -13,8 +13,30 @@ const DEFAULT_METADATA_KEYS = [
   'updatedAt',
   'viewport',
 ]
-
 const DEFAULT_ROOT_KEYS = ['system']
+
+function formatPath(path: string[]): string {
+  return path.length ? path.join('.') : '<root>'
+}
+
+function assertPlainDataObject(
+  value: object,
+  path: string[]
+): asserts value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value)
+
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError(
+      `graph identity supports only plain JSON objects at ${formatPath(path)}`
+    )
+  }
+
+  if (Object.getOwnPropertySymbols(value).length) {
+    throw new TypeError(
+      `graph identity does not support symbol keys at ${formatPath(path)}`
+    )
+  }
+}
 
 function normalize(
   value: unknown,
@@ -41,6 +63,8 @@ function normalize(
   }
 
   if (typeof value === 'object') {
+    assertPlainDataObject(value, path)
+
     const source = value as Record<string, unknown>
     const target: Record<string, unknown> = {}
     const insideMetadata = path[path.length - 1] === 'metadata'
@@ -54,22 +78,52 @@ function normalize(
         continue
       }
 
-      const item = source[key]
+      const descriptor = Object.getOwnPropertyDescriptor(source, key)
+      if (!descriptor) {
+        continue
+      }
+
+      if ('get' in descriptor || 'set' in descriptor) {
+        throw new TypeError(
+          `graph identity does not support accessor properties at ${formatPath([
+            ...path,
+            key,
+          ])}`
+        )
+      }
+
+      const item = descriptor.value
       if (item === undefined) {
         continue
       }
 
-      if (typeof item === 'function' || typeof item === 'symbol' || typeof item === 'bigint') {
-        throw new TypeError(`graph identity does not support ${typeof item} values at ${[...path, key].join('.')}`)
+      if (
+        typeof item === 'function' ||
+        typeof item === 'symbol' ||
+        typeof item === 'bigint'
+      ) {
+        throw new TypeError(
+          `graph identity does not support ${typeof item} values at ${formatPath([
+            ...path,
+            key,
+          ])}`
+        )
       }
 
-      target[key] = normalize(item, metadataKeys, rootKeys, [...path, key])
+      Object.defineProperty(target, key, {
+        value: normalize(item, metadataKeys, rootKeys, [...path, key]),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      })
     }
 
     return target
   }
 
-  throw new TypeError(`graph identity does not support ${typeof value} values at ${path.join('.')}`)
+  throw new TypeError(
+    `graph identity does not support ${typeof value} values at ${formatPath(path)}`
+  )
 }
 
 export function canonicalizeGraphSpec(

--- a/src/test/runtime/capability-calculus.ts
+++ b/src/test/runtime/capability-calculus.ts
@@ -1,0 +1,394 @@
+import * as assert from 'assert'
+import {
+  compileLeastAuthority,
+  isScopedCapabilityAtMost,
+  joinScopedCapabilities,
+  meetScopedCapabilities,
+  normalizeCapabilityClass,
+  normalizeCapabilityScope,
+} from '../../runtime/capability-calculus'
+import {
+  Capability,
+  CapabilityGrant,
+  ScopedCapability,
+} from '../../types/Capability'
+
+const requested: ScopedCapability = {
+  capability: 'network.http',
+  scope: {
+    resources: ['https://api.github.com', 'https://example.invalid'],
+    selectors: { method: ['GET', 'POST'] },
+    limits: { responseBytes: 900 },
+    permissions: { privateNetwork: false },
+  },
+}
+
+const hostCeiling: ScopedCapability = {
+  capability: 'network.http',
+  scope: {
+    resources: ['https://api.github.com', 'https://internal.invalid'],
+    selectors: { method: ['GET', 'POST'] },
+    limits: { responseBytes: 1000 },
+    permissions: { privateNetwork: false },
+  },
+}
+
+const routeCeiling: ScopedCapability = {
+  capability: 'network.http',
+  scope: {
+    resources: ['https://api.github.com'],
+    selectors: { method: ['GET'] },
+    limits: { responseBytes: 500 },
+    permissions: { privateNetwork: false },
+  },
+}
+
+assert.deepEqual(meetScopedCapabilities(requested, hostCeiling), {
+  capability: 'network.http',
+  scope: {
+    resources: ['https://api.github.com'],
+    selectors: { method: ['GET', 'POST'] },
+    limits: { responseBytes: 900 },
+    permissions: { privateNetwork: false },
+  },
+})
+
+assert.deepEqual(joinScopedCapabilities(routeCeiling, hostCeiling), {
+  capability: 'network.http',
+  scope: {
+    resources: ['https://api.github.com', 'https://internal.invalid'],
+    selectors: { method: ['GET', 'POST'] },
+    limits: { responseBytes: 1000 },
+    permissions: { privateNetwork: false },
+  },
+})
+
+assert.equal(isScopedCapabilityAtMost(routeCeiling, hostCeiling), true)
+assert.equal(isScopedCapabilityAtMost(hostCeiling, routeCeiling), false)
+assert.equal(normalizeCapabilityClass('extension.example'), 'extension.example')
+assert.throws(
+  () => normalizeCapabilityClass('network.http.elevated' as Capability),
+  /unsupported capability class/
+)
+assert.throws(
+  () => normalizeCapabilityClass('extension.' as Capability),
+  /unsupported capability class/
+)
+assert.throws(
+  () => normalizeCapabilityClass('extension.Example' as Capability),
+  /unsupported capability class/
+)
+assert.throws(
+  () => normalizeCapabilityScope({ resources: [] }),
+  /at least one resource/
+)
+assert.throws(
+  () => normalizeCapabilityScope({ selectors: { method: [] } }),
+  /selector must allow at least one value/
+)
+assert.throws(
+  () =>
+    normalizeCapabilityScope({
+      resources: ['https://api.github.com'],
+      scopee: ['https://evil.invalid'],
+    } as unknown as never),
+  /capability scope contains unknown key: scopee/
+)
+assert.throws(
+  () =>
+    normalizeCapabilityScope({
+      permissions: { privateNetwork: 'false' },
+    } as unknown as never),
+  /capability permission must be boolean/
+)
+assert.throws(
+  () =>
+    normalizeCapabilityScope({
+      selectors: { constructor: ['GET'] },
+    }),
+  /reserved/
+)
+
+function grant(
+  grantId: string,
+  capabilities: ScopedCapability[],
+  budget?: { networkBytes?: number; toolCalls?: number }
+): CapabilityGrant {
+  return {
+    version: 'unit.capability-grant/1',
+    grantId,
+    principalId: 'principal-1',
+    requestId: 'request-1',
+    operationId: 'operation-1',
+    capabilities,
+    issuedAt: '2026-08-10T00:00:00.000Z',
+    expiresAt: '2026-08-11T00:00:00.000Z',
+    budget,
+  }
+}
+
+const proof = compileLeastAuthority(
+  { required: [requested] },
+  {
+    principalId: 'principal-1',
+    requestId: 'request-1',
+    operationId: 'operation-1',
+    now: '2026-08-10T12:00:00.000Z',
+    layers: [
+      grant('host', [hostCeiling], { networkBytes: 1000, toolCalls: 4 }),
+      grant('route', [routeCeiling], { networkBytes: 600, toolCalls: 2 }),
+    ],
+  }
+)
+
+assert.equal(proof.allowed, true)
+assert.equal(proof.monotonic, true)
+assert.deepEqual(proof.grantIds, ['host', 'route'])
+assert.deepEqual(proof.effective, [routeCeiling])
+assert.deepEqual(proof.residue, [requested])
+assert.deepEqual(proof.budget, { networkBytes: 600, toolCalls: 2 })
+
+const denied = compileLeastAuthority(
+  {
+    required: [{ capability: 'process.spawn' }],
+    optional: [{ capability: 'network.http' }],
+  },
+  {
+    principalId: 'principal-1',
+    requestId: 'request-1',
+    operationId: 'operation-1',
+    now: '2026-08-10T12:00:00.000Z',
+    layers: [grant('network-only', [hostCeiling])],
+  }
+)
+
+assert.equal(denied.allowed, false)
+assert.deepEqual(denied.deniedRequired, [{ capability: 'process.spawn' }])
+
+const noGrantRequired = compileLeastAuthority(
+  { required: [{ capability: 'network.http' }] },
+  {
+    principalId: 'principal-1',
+    requestId: 'request-1',
+    operationId: 'operation-1',
+    now: '2026-08-10T12:00:00.000Z',
+    layers: [],
+  }
+)
+
+assert.equal(noGrantRequired.allowed, false)
+assert.deepEqual(noGrantRequired.effective, [])
+assert.deepEqual(noGrantRequired.deniedRequired, [
+  { capability: 'network.http' },
+])
+
+const noGrantOptional = compileLeastAuthority(
+  { optional: [{ capability: 'network.http' }] },
+  {
+    principalId: 'principal-1',
+    requestId: 'request-1',
+    operationId: 'operation-1',
+    now: '2026-08-10T12:00:00.000Z',
+    layers: [],
+  }
+)
+
+assert.equal(noGrantOptional.allowed, true)
+assert.deepEqual(noGrantOptional.effective, [])
+assert.deepEqual(noGrantOptional.deniedOptional, [
+  { capability: 'network.http' },
+])
+
+const noGrantNoAuthority = compileLeastAuthority(
+  {},
+  {
+    principalId: 'principal-1',
+    requestId: 'request-1',
+    operationId: 'operation-1',
+    now: '2026-08-10T12:00:00.000Z',
+    layers: [],
+  }
+)
+
+assert.equal(noGrantNoAuthority.allowed, true)
+assert.deepEqual(noGrantNoAuthority.effective, [])
+
+const conflict = compileLeastAuthority(
+  {
+    required: [
+      { capability: 'network.http' },
+      { capability: 'process.spawn' },
+    ],
+  },
+  {
+    principalId: 'principal-1',
+    requestId: 'request-1',
+    operationId: 'operation-1',
+    now: '2026-08-10T12:00:00.000Z',
+    layers: [
+      grant('broad-host', [
+        { capability: 'network.http' },
+        { capability: 'process.spawn' },
+      ]),
+    ],
+    conflictRules: [
+      {
+        id: 'unrestricted-network-plus-process',
+        allOf: ['network.http', 'process.spawn'],
+      },
+    ],
+  }
+)
+
+assert.equal(conflict.allowed, false)
+assert.deepEqual(conflict.conflicts, ['unrestricted-network-plus-process'])
+
+assert.throws(
+  () =>
+    compileLeastAuthority(
+      { required: [{ capability: 'network.http' }] },
+      {
+        principalId: 'principal-1',
+        requestId: 'request-1',
+        operationId: 'operation-1',
+        now: '2026-08-10T12:00:00.000Z',
+        layers: [
+          grant('duplicate', [hostCeiling]),
+          grant('duplicate', [routeCeiling]),
+        ],
+      }
+    ),
+  /duplicate capability grant id/
+)
+
+assert.throws(
+  () =>
+    compileLeastAuthority(
+      { required: [{ capability: 'network.http' }] },
+      {
+        principalId: 'principal-1',
+        requestId: 'request-1',
+        operationId: 'operation-1',
+        now: '2026-08-10T12:00:00.000Z',
+        layers: [
+          {
+            ...grant('unknown-grant-key', [hostCeiling]),
+            parentGrantId: 'not-supported-in-v0.1',
+          } as unknown as CapabilityGrant,
+        ],
+      }
+    ),
+  /capability grant contains unknown key: parentGrantId/
+)
+
+assert.throws(
+  () =>
+    compileLeastAuthority(
+      { required: [{ capability: 'network.http' }] },
+      {
+        principalId: 'principal-1',
+        requestId: 'request-1',
+        operationId: 'operation-1',
+        now: '2026-08-10T12:00:00',
+        layers: [grant('ambiguous-time', [hostCeiling])],
+      }
+    ),
+  /explicit UTC or numeric timezone offset/
+)
+
+assert.throws(
+  () =>
+    compileLeastAuthority(
+      { required: [{ capability: 'network.http' }] },
+      {
+        principalId: 'principal-1',
+        requestId: 'request-1',
+        operationId: 'operation-1',
+        now: '2026-08-10T12:00:00.000Z',
+        layers: [
+          {
+            ...grant('grant-ambiguous-time', [hostCeiling]),
+            issuedAt: '2026-08-10T00:00:00',
+          },
+        ],
+      }
+    ),
+  /explicit UTC or numeric timezone offset/
+)
+
+assert.throws(
+  () =>
+    compileLeastAuthority(
+      { required: [{ capability: 'network.http' }] },
+      {
+        principalId: 'principal-1',
+        requestId: 'request-1',
+        operationId: 'operation-1',
+        now: '2026-08-10T12:00:00.000Z',
+        layers: [grant('duplicate-conflict-host', [hostCeiling])],
+        conflictRules: [
+          { id: 'same-rule', allOf: ['network.http'] },
+          { id: 'same-rule', allOf: ['network.http'] },
+        ],
+      }
+    ),
+  /duplicate capability conflict rule id/
+)
+
+assert.throws(
+  () =>
+    compileLeastAuthority(
+      { required: [{ capability: 'network.http' }] },
+      {
+        principalId: 'principal-1',
+        requestId: 'request-1',
+        operationId: 'operation-1',
+        now: '2026-08-12T00:00:00.000Z',
+        layers: [grant('expired', [hostCeiling])],
+      }
+    ),
+  /expired/
+)
+
+assert.throws(
+  () =>
+    compileLeastAuthority(
+      { required: [{ capability: 'network.http' }] },
+      {
+        principalId: 'principal-2',
+        requestId: 'request-1',
+        operationId: 'operation-1',
+        now: '2026-08-10T12:00:00.000Z',
+        layers: [grant('wrong-principal', [hostCeiling])],
+      }
+    ),
+  /principal mismatch/
+)
+
+const scopeCases = [
+  ['https://api.github.com'],
+  ['https://api.github.com', 'https://example.invalid'],
+  ['https://example.invalid'],
+]
+
+for (const resources of scopeCases) {
+  const requestCapability: ScopedCapability = {
+    capability: 'network.http',
+    scope: { resources },
+  }
+  const propertyProof = compileLeastAuthority(
+    { required: [requestCapability] },
+    {
+      principalId: 'principal-1',
+      requestId: 'request-1',
+      operationId: 'operation-1',
+      now: '2026-08-10T12:00:00.000Z',
+      layers: [grant('property-host', [hostCeiling])],
+    }
+  )
+
+  for (const effective of propertyProof.effective) {
+    assert.equal(isScopedCapabilityAtMost(effective, requestCapability), true)
+    assert.equal(isScopedCapabilityAtMost(effective, hostCeiling), true)
+  }
+}

--- a/src/test/runtime/capability-lattice.ts
+++ b/src/test/runtime/capability-lattice.ts
@@ -1,0 +1,114 @@
+import * as assert from 'assert'
+import {
+  isScopedCapabilityAtMost,
+  joinScopedCapabilities,
+  meetScopedCapabilities,
+} from '../../runtime/capability-calculus'
+import { ScopedCapability } from '../../types/Capability'
+
+const fixtures: ScopedCapability[] = [
+  { capability: 'network.http' },
+  {
+    capability: 'network.http',
+    scope: {
+      resources: ['a', 'b'],
+      selectors: { method: ['GET', 'POST'] },
+      limits: { bytes: 1000 },
+      permissions: { privateNetwork: true },
+    },
+  },
+  {
+    capability: 'network.http',
+    scope: {
+      resources: ['a'],
+      selectors: { method: ['GET'] },
+      limits: { bytes: 500 },
+      permissions: { privateNetwork: false },
+    },
+  },
+  {
+    capability: 'network.http',
+    scope: {
+      resources: ['b'],
+      selectors: { method: ['POST'] },
+      limits: { bytes: 250 },
+      permissions: { privateNetwork: false },
+    },
+  },
+]
+
+function same(
+  a: ScopedCapability | null,
+  b: ScopedCapability | null
+): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+for (const value of fixtures) {
+  assert.deepEqual(meetScopedCapabilities(value, value), value)
+  assert.deepEqual(joinScopedCapabilities(value, value), value)
+}
+
+for (const left of fixtures) {
+  for (const right of fixtures) {
+    const meetLR = meetScopedCapabilities(left, right)
+    const meetRL = meetScopedCapabilities(right, left)
+    const joinLR = joinScopedCapabilities(left, right)
+    const joinRL = joinScopedCapabilities(right, left)
+
+    assert.equal(same(meetLR, meetRL), true, 'meet must be commutative')
+    assert.equal(same(joinLR, joinRL), true, 'join must be commutative')
+
+    if (meetLR) {
+      assert.equal(isScopedCapabilityAtMost(meetLR, left), true)
+      assert.equal(isScopedCapabilityAtMost(meetLR, right), true)
+    }
+
+    if (joinLR) {
+      assert.equal(isScopedCapabilityAtMost(left, joinLR), true)
+      assert.equal(isScopedCapabilityAtMost(right, joinLR), true)
+    }
+
+    const absorbMeet = meetScopedCapabilities(left, joinLR!)
+    assert.deepEqual(absorbMeet, left)
+
+    if (meetLR) {
+      const absorbJoin = joinScopedCapabilities(left, meetLR)
+      assert.deepEqual(absorbJoin, left)
+    }
+  }
+}
+
+for (const a of fixtures) {
+  for (const b of fixtures) {
+    for (const c of fixtures) {
+      const abMeet = meetScopedCapabilities(a, b)
+      const bcMeet = meetScopedCapabilities(b, c)
+      const leftMeet = abMeet ? meetScopedCapabilities(abMeet, c) : null
+      const rightMeet = bcMeet ? meetScopedCapabilities(a, bcMeet) : null
+      assert.equal(same(leftMeet, rightMeet), true, 'meet must be associative')
+
+      const abJoin = joinScopedCapabilities(a, b)
+      const bcJoin = joinScopedCapabilities(b, c)
+      const leftJoin = abJoin ? joinScopedCapabilities(abJoin, c) : null
+      const rightJoin = bcJoin ? joinScopedCapabilities(a, bcJoin) : null
+      assert.equal(same(leftJoin, rightJoin), true, 'join must be associative')
+    }
+  }
+}
+
+assert.equal(
+  meetScopedCapabilities(
+    { capability: 'network.http', scope: { resources: ['a'] } },
+    { capability: 'network.http', scope: { resources: ['b'] } }
+  ),
+  null
+)
+
+assert.equal(
+  meetScopedCapabilities(
+    { capability: 'network.http' },
+    { capability: 'process.spawn' }
+  ),
+  null
+)

--- a/src/test/runtime/capability.ts
+++ b/src/test/runtime/capability.ts
@@ -4,6 +4,7 @@ import {
   evaluateCapabilityManifest,
   normalizeCapabilityManifest,
 } from '../../runtime/capability'
+import { CapabilityManifest } from '../../types/Capability'
 
 const manifest = normalizeCapabilityManifest({
   required: ['network.http', 'network.http'],
@@ -15,6 +16,17 @@ assert.deepEqual(manifest, {
   optional: ['media.microphone'],
 })
 
+assert.deepEqual(
+  normalizeCapabilityManifest({
+    required: [' network.http ' as 'network.http'],
+    optional: ['network.http', ' media.microphone ' as 'media.microphone'],
+  }),
+  {
+    required: ['network.http'],
+    optional: ['media.microphone'],
+  }
+)
+
 assert.deepEqual(evaluateCapabilityManifest(manifest, ['network.http']), {
   granted: ['network.http'],
   deniedRequired: [],
@@ -25,4 +37,29 @@ assert.deepEqual(evaluateCapabilityManifest(manifest, ['network.http']), {
 assert.throws(
   () => assertCapabilities(manifest, ['media.microphone']),
   /network\.http/
+)
+
+assert.throws(
+  () =>
+    normalizeCapabilityManifest({
+      required: ['network.http'],
+      availableCapabilities: ['process.spawn'],
+    } as unknown as CapabilityManifest),
+  /capability manifest contains unknown key/
+)
+
+assert.throws(
+  () =>
+    normalizeCapabilityManifest({
+      required: ['network.http.elevated'],
+    } as unknown as CapabilityManifest),
+  /unsupported capability class/
+)
+
+assert.throws(
+  () =>
+    normalizeCapabilityManifest({
+      required: 'network.http',
+    } as unknown as CapabilityManifest),
+  /required capabilities must be an array/
 )

--- a/src/test/runtime/index.ts
+++ b/src/test/runtime/index.ts
@@ -1,3 +1,5 @@
 import './capability'
+import './capability-calculus'
+import './capability-lattice'
 import './conformance'
 import './interoperability'

--- a/src/test/runtime/interoperability.ts
+++ b/src/test/runtime/interoperability.ts
@@ -4,11 +4,13 @@ import {
   classifyRuntimeSourceModality,
   normalizeRuntimeSources,
   runRuntimeInvocation,
+  RuntimeAuthorization,
   RuntimeInvocation,
 } from '../../runtime/interoperability'
 import {
   GraphRuntime,
   InstantiateGraphOptions,
+  RuntimeAuthorityEnforcement,
   RuntimeEvent,
   RuntimeSnapshot,
 } from '../../runtime/contract'
@@ -39,7 +41,7 @@ assert.deepEqual(
       kind: 'inline',
       modality: 'structured',
       mediaType: 'application/json',
-      digest: 'abc123',
+      digest: 'ABC123',
     },
     {
       id: 'source-b',
@@ -60,20 +62,38 @@ assert.throws(
   /duplicate runtime source id/
 )
 
+assert.throws(
+  () =>
+    normalizeRuntimeSources([
+      {
+        id: 'bad-source',
+        kind: 'uri',
+        unexpected: true,
+      } as unknown as never,
+    ]),
+  /runtime source contains unknown key/
+)
+
 class MemoryRuntime implements GraphRuntime {
+  readonly authorityEnforcement: RuntimeAuthorityEnforcement = {
+    scopedCapabilities: 'unit.scoped-capabilities/1',
+    resourceBudgets: 'unit.resource-budgets/1',
+  }
   private data = new Map<string, Record<string, unknown>>()
   private hashes = new Map<string, string>()
   public stopped: string[] = []
+  public options: InstantiateGraphOptions[] = []
 
   validate(_spec: GraphSpec): void {}
 
   async instantiate(
     spec: GraphSpec,
-    _options?: InstantiateGraphOptions
+    options: InstantiateGraphOptions = {}
   ): Promise<string> {
     const graphId = `graph-${this.data.size}`
     this.data.set(graphId, {})
     this.hashes.set(graphId, await hashGraphSpec(spec))
+    this.options.push(options)
     return graphId
   }
 
@@ -109,6 +129,16 @@ class MemoryRuntime implements GraphRuntime {
   async *events(_graphId: string): AsyncIterable<RuntimeEvent> {}
 }
 
+class UnsupportedAuthorityRuntime extends MemoryRuntime {
+  override readonly authorityEnforcement: RuntimeAuthorityEnforcement = {}
+}
+
+class ScopeOnlyRuntime extends MemoryRuntime {
+  override readonly authorityEnforcement: RuntimeAuthorityEnforcement = {
+    scopedCapabilities: 'unit.scoped-capabilities/1',
+  }
+}
+
 class PushFailureRuntime extends MemoryRuntime {
   push(_graphId: string, _pinId: string, _data: unknown): void {
     throw new Error('push failure')
@@ -117,12 +147,20 @@ class PushFailureRuntime extends MemoryRuntime {
 
 const invocation: RuntimeInvocation = {
   requestId: ' expression-route-1 ',
+  operationId: ' render-expression ',
   spec: { id: 'interop-fixture', name: 'interoperability fixture' },
-  manifest: {
-    required: ['network.http'],
-    optional: ['media.microphone'],
+  capabilityRequest: {
+    required: [
+      {
+        capability: 'network.http',
+        scope: {
+          resources: ['https://api.github.com', 'https://example.invalid'],
+          selectors: { method: ['GET', 'POST'] },
+        },
+      },
+    ],
+    optional: [{ capability: 'media.microphone' }],
   },
-  availableCapabilities: ['network.http'],
   sources: [
     {
       id: 'source-1',
@@ -135,29 +173,180 @@ const invocation: RuntimeInvocation = {
   outputs: [{ pinId: 'value' }],
 }
 
+function authorizationFor(
+  requestId: string,
+  operationId = 'render-expression'
+): RuntimeAuthorization {
+  return {
+    principalId: 'principal-1',
+    manifest: {
+      required: ['network.http'],
+      optional: ['media.microphone'],
+    },
+    now: '2026-08-10T12:00:00.000Z',
+    layers: [
+      {
+        version: 'unit.capability-grant/1',
+        grantId: `grant-${requestId}`,
+        principalId: 'principal-1',
+        requestId,
+        operationId,
+        capabilities: [
+          {
+            capability: 'network.http',
+            scope: {
+              resources: ['https://api.github.com'],
+              selectors: { method: ['GET'] },
+            },
+          },
+        ],
+        issuedAt: '2026-08-10T00:00:00.000Z',
+        expiresAt: '2026-08-11T00:00:00.000Z',
+        budget: { networkBytes: 1000, toolCalls: 1 },
+      },
+    ],
+  }
+}
+
 const runtime = new MemoryRuntime()
 
-void runRuntimeInvocation(runtime, invocation)
+void runRuntimeInvocation(
+  runtime,
+  invocation,
+  authorizationFor('expression-route-1')
+)
   .then((result) => {
     assert.deepEqual(result.outputs, { value: 42 })
+    assert.equal(result.evidence.version, 'unit.runtime-evidence/2')
     assert.equal(result.evidence.requestId, 'expression-route-1')
+    assert.equal(result.evidence.operationId, 'render-expression')
+    assert.equal(result.evidence.principalId, 'principal-1')
     assert.equal(result.evidence.sources[0].modality, 'text')
-    assert.equal(result.evidence.sources[0].digest, 'abcdef')
+    assert.equal(result.evidence.sources[0].digest, 'ABCDEF')
     assert.deepEqual(result.evidence.inputs, [
       { pinId: 'value', sourceId: 'source-1' },
     ])
-    assert.deepEqual(result.evidence.capabilities, {
-      required: ['network.http'],
-      optional: ['media.microphone'],
-      granted: ['network.http'],
-      deniedRequired: [],
-      deniedOptional: ['media.microphone'],
-      allowed: true,
+    assert.equal(result.evidence.capabilities.allowed, true)
+    assert.equal(result.evidence.capabilities.monotonic, true)
+    assert.deepEqual(result.evidence.capabilities.grantIds, [
+      'grant-expression-route-1',
+    ])
+    assert.deepEqual(result.evidence.capabilities.deniedOptional, [
+      { capability: 'media.microphone' },
+    ])
+    assert.deepEqual(result.evidence.capabilities.effective, [
+      {
+        capability: 'network.http',
+        scope: {
+          resources: ['https://api.github.com'],
+          selectors: { method: ['GET'] },
+        },
+      },
+    ])
+    assert.deepEqual(result.evidence.capabilities.budget, {
+      networkBytes: 1000,
+      toolCalls: 1,
+    })
+    assert.deepEqual(result.evidence.enforcement, {
+      scopedCapabilities: 'unit.scoped-capabilities/1',
+      resourceBudgets: 'unit.resource-budgets/1',
     })
     assert.equal(result.evidence.snapshot.sequence, 7)
     assert.equal(result.evidence.graphHash, result.snapshot.graphHash)
     assert.deepEqual(runtime.stopped, ['graph-0'])
+    assert.deepEqual(runtime.options[0].capabilities, ['network.http'])
+    assert.deepEqual(runtime.options[0].manifest, {
+      required: ['network.http'],
+      optional: ['media.microphone'],
+    })
+    assert.deepEqual(
+      runtime.options[0].scopedCapabilities,
+      result.evidence.capabilities.effective
+    )
   })
+  .catch((error) => {
+    setImmediate(() => {
+      throw error
+    })
+  })
+
+const forgedRuntime = new MemoryRuntime()
+const forgedInvocation = {
+  ...invocation,
+  requestId: 'forged-request',
+  availableCapabilities: ['process.spawn'],
+  manifest: {
+    required: ['process.spawn'],
+  },
+}
+
+void runRuntimeInvocation(
+  forgedRuntime,
+  forgedInvocation,
+  authorizationFor('forged-request')
+)
+  .then(
+    () => {
+      throw new Error('expected forged invocation schema to be rejected')
+    },
+    (error) => {
+      assert.match(String(error), /runtime invocation contains unknown key/)
+      assert.deepEqual(forgedRuntime.options, [])
+      assert.deepEqual(forgedRuntime.stopped, [])
+    }
+  )
+  .catch((error) => {
+    setImmediate(() => {
+      throw error
+    })
+  })
+
+const unsupportedRuntime = new UnsupportedAuthorityRuntime()
+
+void runRuntimeInvocation(
+  unsupportedRuntime,
+  {
+    ...invocation,
+    requestId: 'unsupported-scope',
+  },
+  authorizationFor('unsupported-scope')
+)
+  .then(
+    () => {
+      throw new Error('expected scoped capability enforcement refusal')
+    },
+    (error) => {
+      assert.match(String(error), /scoped capability enforcement is required/)
+      assert.deepEqual(unsupportedRuntime.options, [])
+      assert.deepEqual(unsupportedRuntime.stopped, [])
+    }
+  )
+  .catch((error) => {
+    setImmediate(() => {
+      throw error
+    })
+  })
+
+const scopeOnlyRuntime = new ScopeOnlyRuntime()
+
+void runRuntimeInvocation(
+  scopeOnlyRuntime,
+  {
+    ...invocation,
+    requestId: 'unsupported-budget',
+  },
+  authorizationFor('unsupported-budget')
+)
+  .then(
+    () => {
+      throw new Error('expected resource budget enforcement refusal')
+    },
+    (error) => {
+      assert.match(String(error), /resource budget enforcement is required/)
+      assert.deepEqual(scopeOnlyRuntime.options, [])
+      assert.deepEqual(scopeOnlyRuntime.stopped, [])
+    }
+  )
   .catch((error) => {
     setImmediate(() => {
       throw error
@@ -166,10 +355,14 @@ void runRuntimeInvocation(runtime, invocation)
 
 const failingRuntime = new PushFailureRuntime()
 
-void runRuntimeInvocation(failingRuntime, {
-  ...invocation,
-  requestId: 'expression-route-failure',
-})
+void runRuntimeInvocation(
+  failingRuntime,
+  {
+    ...invocation,
+    requestId: 'expression-route-failure',
+  },
+  authorizationFor('expression-route-failure')
+)
   .then(
     () => {
       throw new Error('expected runtime invocation to fail')

--- a/src/test/spec/identity.ts
+++ b/src/test/spec/identity.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert'
 import {
   canonicalGraphString,
+  canonicalizeGraphSpec,
   hashGraphSpec,
 } from '../../spec/identity'
 import { GraphSpec } from '../../types/GraphSpec'
@@ -37,6 +38,58 @@ assert.equal(canonicalGraphString({ id: 'x', value: -0 } as any), '{"id":"x","va
 assert.throws(
   () => canonicalGraphString({ id: 'x', value: Infinity } as any),
   /non-finite/
+)
+
+const protoInput = JSON.parse('{"id":"proto","__proto__":{"polluted":true}}') as GraphSpec
+const protoCanonical = canonicalizeGraphSpec(protoInput, {
+  omitMetadataKeys: [],
+  omitRootKeys: [],
+}) as GraphSpec & Record<string, unknown>
+
+assert.equal(Object.getPrototypeOf(protoCanonical), Object.prototype)
+assert.equal(Object.prototype.hasOwnProperty.call(protoCanonical, '__proto__'), true)
+assert.deepEqual(protoCanonical['__proto__'], { polluted: true })
+assert.equal(({} as { polluted?: boolean }).polluted, undefined)
+assert.equal(
+  canonicalGraphString(protoInput, {
+    omitMetadataKeys: [],
+    omitRootKeys: [],
+  }),
+  '{"__proto__":{"polluted":true},"id":"proto"}'
+)
+
+assert.throws(
+  () => canonicalGraphString({ id: 'date', value: new Date() } as any),
+  /plain JSON objects/
+)
+assert.throws(
+  () => canonicalGraphString({ id: 'map', value: new Map() } as any),
+  /plain JSON objects/
+)
+
+class GraphLike {
+  id = 'class-instance'
+}
+
+assert.throws(
+  () => canonicalGraphString(new GraphLike() as unknown as GraphSpec),
+  /plain JSON objects/
+)
+
+const symbolGraph = { id: 'symbol' } as GraphSpec & Record<PropertyKey, unknown>
+symbolGraph[Symbol('hidden')] = true
+assert.throws(() => canonicalGraphString(symbolGraph), /symbol keys/)
+
+const accessorGraph: Record<string, unknown> = { id: 'accessor' }
+Object.defineProperty(accessorGraph, 'danger', {
+  enumerable: true,
+  get() {
+    throw new Error('getter must not execute')
+  },
+})
+assert.throws(
+  () => canonicalGraphString(accessorGraph as GraphSpec),
+  /accessor properties/
 )
 
 void Promise.all([hashGraphSpec(left), hashGraphSpec(right)])

--- a/src/types/Capability.ts
+++ b/src/types/Capability.ts
@@ -21,3 +21,76 @@ export type CapabilityDecision = {
   deniedOptional: Capability[]
   allowed: boolean
 }
+
+export type CapabilityScope = {
+  resources?: string[]
+  selectors?: Record<string, string[]>
+  limits?: Record<string, number>
+  permissions?: Record<string, boolean>
+}
+
+export type ScopedCapability = {
+  capability: Capability
+  scope?: CapabilityScope
+}
+
+export type CapabilityRequest = {
+  required?: ScopedCapability[]
+  optional?: ScopedCapability[]
+}
+
+export type ResourceBudget = {
+  wallTimeMs?: number
+  cpuTimeMs?: number
+  memoryBytes?: number
+  processCount?: number
+  graphSteps?: number
+  inputBytes?: number
+  outputBytes?: number
+  networkBytes?: number
+  filesystemBytes?: number
+  toolCalls?: number
+}
+
+export type CapabilityGrant = {
+  version: 'unit.capability-grant/1'
+  grantId: string
+  principalId: string
+  requestId: string
+  operationId: string
+  capabilities: ScopedCapability[]
+  issuedAt: string
+  expiresAt: string
+  budget?: ResourceBudget
+}
+
+export type CapabilityConflictRule = {
+  id: string
+  allOf: Capability[]
+}
+
+export type CapabilityAuthorizationContext = {
+  principalId: string
+  requestId: string
+  operationId: string
+  layers: CapabilityGrant[]
+  conflictRules?: CapabilityConflictRule[]
+  now?: string
+}
+
+export type CapabilityProof = {
+  version: 'unit.capability-proof/1'
+  requestId: string
+  operationId: string
+  principalId: string
+  grantIds: string[]
+  requested: Required<CapabilityRequest>
+  effective: ScopedCapability[]
+  deniedRequired: ScopedCapability[]
+  deniedOptional: ScopedCapability[]
+  residue: ScopedCapability[]
+  conflicts: string[]
+  monotonic: boolean
+  allowed: boolean
+  budget?: ResourceBudget
+}


### PR DESCRIPTION
## Summary

Implements Capability Calculus v0.1 as a generic security-aware Unit kernel contract:

- scoped capability lattice with meet, analysis-only join, and partial-order semantics;
- trusted-host capability declaration separated from caller-visible invocation data;
- default-deny least-authority compilation across conjunctive grant/ceiling layers;
- principal/request/operation/time-bound grants with unique proof identity;
- capability residue, monotonicity proof, resource-budget attenuation, and generic conflict/refusal rules;
- exact runtime schema validation for manifests, requests, scopes, grants, budgets, conflict rules, sources, inputs, outputs, and authorization envelopes;
- runtime capability-vocabulary validation and malformed extension rejection;
- scope/budget enforcement compatibility markers that refuse semantic downgrade before graph instantiation;
- hardened canonical graph identity against prototype pollution, accessors, symbol keys, non-JSON object classes, and non-finite execution objects;
- `unit.runtime-evidence/2` binding principal, operation, grant IDs, effective authority, budget, enforcement profile, graph identity, and snapshot identity;
- lattice-law, adversarial, lifecycle, and interoperability conformance tests;
- architecture and repository-boundary documentation.

## Core invariant

```text
EffectiveAuthority
  = RequestedScope
  ∧ HostGrant
  ∧ AdditionalTrustedCeilings
```

Every authority layer may attenuate but never amplify. Required authority without a trusted grant fails closed. Scoped authority or budgeted execution is refused when the target runtime does not advertise the corresponding enforcement contract.

## Repository boundary

Unit does **not** interpret human/agent goals or embed IAM/product policy. Downstream control planes remain responsible for organizational roles, approvals, credentials, durable replay/revocation, resource-specific canonicalization, browser/network/filesystem policy, and product receipts. They compile those concerns into generic host manifests, scoped requests, grants/ceilings, conflict rules, budgets, and adapter enforcement.

V0.1 deliberately does not expose unenforced delegation metadata, single-use/revocation semantics, or cryptographic grant-to-graph binding.

## Qualification target

Existing read-only PR CI only:

- `npm ci`
- dependency audit + critical floor
- build
- generated registry parity
- lint
- typecheck
- runtime tests, including lattice/adversarial conformance
- Workstation Validation

Final candidate is squashed to one commit over `main`; no workflow files are modified.